### PR TITLE
refactor: add projectName config option

### DIFF
--- a/src/commands/social.ts
+++ b/src/commands/social.ts
@@ -147,7 +147,7 @@ async function handleTwitterPost({
       const response = await postReleaseToTwitter({
         template: config.social.twitter.template || config.templates.twitterMessage,
         version: newVersion,
-        projectName: rootPackageBase.name,
+        projectName: config.projectName || rootPackageBase.name,
         changelog,
         releaseUrl,
         changelogUrl,
@@ -249,7 +249,7 @@ async function handleSlackPost({
 
       const response = await postReleaseToSlack({
         version: newVersion,
-        projectName: rootPackageBase.name,
+        projectName: config.projectName || rootPackageBase.name,
         changelog,
         releaseUrl,
         changelogUrl,

--- a/src/types.ts
+++ b/src/types.ts
@@ -862,6 +862,12 @@ export type HookConfig = {
  * @see https://louismazel.github.io/relizy/config/overview
  */
 export interface RelizyConfig extends Partial<Omit<IChangelogConfig, 'output' | 'templates' | 'publish' | 'types' | 'tokens'>> {
+  /**
+   * Project name
+   * Useful for tweet and slack posts
+   */
+  projectName?: string
+
   types?: Record<string, {
     title: string
     semver?: SemverBumpType


### PR DESCRIPTION
Allows overriding the package name from root package.json for Twitter (X) and Slack posts. Use `projectName` in your config to customize the displayed name in social notifications.

## Description

<!-- Provide a brief description of the changes in this PR -->

## Type of Change

<!-- Check the type of change your PR introduces -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code style/UI update (formatting, renaming, etc; no functional changes)
- [x] Refactor (no functional changes, code improvements)
- [ ] Documentation update
- [ ] Tests (adding missing tests or correcting existing tests)
- [ ] Build/CI related changes
- [ ] Dependencies update
- [ ] Performance improvements
- [ ] Other (please describe):

