### PR TITLE
fix(relizy): compute per-package canary versions in independent mode

### DIFF
--- a/src/commands/__tests__/bump.spec.ts
+++ b/src/commands/__tests__/bump.spec.ts
@@ -1040,5 +1040,160 @@ describe('Given bump command', () => {
 
       expect(result.bumped).toBe(false)
     })
+
+    it('Then computes per-package canary versions in independent mode', async () => {
+      vi.mocked(loadRelizyConfig).mockResolvedValueOnce({
+        cwd: mockCwd,
+        bump: {
+          type: 'release',
+          yes: true,
+        },
+        release: { clean: false },
+        monorepo: {
+          versionMode: 'independent',
+          packages: ['packages/*'],
+        },
+        types: {
+          feat: { title: 'Features', semver: 'minor' },
+          fix: { title: 'Bug Fixes', semver: 'patch' },
+        },
+        templates: { tagBody: '{{newVersion}}' },
+        logLevel: 'default',
+      } as unknown as ResolvedRelizyConfig)
+
+      vi.mocked(getShortCommitSha).mockReturnValueOnce('abc1234')
+
+      const featCommit = createMockCommit('feat', 'add feature')
+      const fixCommit = createMockCommit('fix', 'fix bug')
+
+      vi.mocked(getPackages).mockResolvedValueOnce([
+        {
+          name: '@my-org/ui',
+          version: '9.1.0',
+          path: `${mockCwd}/packages/ui`,
+          newVersion: '9.2.0',
+          reason: 'commits',
+          commits: [featCommit],
+          fromTag: '@my-org/ui@9.1.0',
+          dependencies: [],
+          private: false,
+        },
+        {
+          name: '@my-org/config',
+          version: '1.2.0',
+          path: `${mockCwd}/packages/config`,
+          newVersion: '1.2.1',
+          reason: 'commits',
+          commits: [fixCommit],
+          fromTag: '@my-org/config@1.2.0',
+          dependencies: [],
+          private: false,
+        },
+      ])
+
+      // determineSemverChange is called per-package in independent canary mode
+      vi.mocked(determineSemverChange)
+        .mockReturnValueOnce('minor') // @my-org/ui has feat commit
+        .mockReturnValueOnce('patch') // @my-org/config has fix commit
+
+      vi.mocked(getCanaryVersion)
+        .mockReturnValueOnce('9.2.0-canary.abc1234.0') // @my-org/ui
+        .mockReturnValueOnce('1.2.1-canary.abc1234.0') // @my-org/config
+
+      const result = await bump({
+        canary: true,
+        yes: true,
+      })
+
+      expect(result.bumped).toBe(true)
+      if (result.bumped) {
+        // In independent mode, no single newVersion or rootPackage
+        expect(result.newVersion).toBeUndefined()
+        expect(result.rootPackage).toBeUndefined()
+
+        expect(result.bumpedPackages).toHaveLength(2)
+        expect(result.bumpedPackages[0].name).toBe('@my-org/ui')
+        expect(result.bumpedPackages[0].newVersion).toBe('9.2.0-canary.abc1234.0')
+        expect(result.bumpedPackages[0].oldVersion).toBe('9.1.0')
+
+        expect(result.bumpedPackages[1].name).toBe('@my-org/config')
+        expect(result.bumpedPackages[1].newVersion).toBe('1.2.1-canary.abc1234.0')
+        expect(result.bumpedPackages[1].oldVersion).toBe('1.2.0')
+      }
+
+      // getCanaryVersion should be called with each package's own version
+      expect(getCanaryVersion).toHaveBeenCalledWith({
+        currentVersion: '9.1.0',
+        releaseType: 'minor',
+        preid: 'canary',
+        sha: 'abc1234',
+      })
+      expect(getCanaryVersion).toHaveBeenCalledWith({
+        currentVersion: '1.2.0',
+        releaseType: 'patch',
+        preid: 'canary',
+        sha: 'abc1234',
+      })
+
+      // Should NOT read root package.json or resolve root tags
+      expect(readPackageJson).not.toHaveBeenCalled()
+      expect(resolveTags).not.toHaveBeenCalled()
+      expect(getPackageCommits).not.toHaveBeenCalled()
+
+      // writeVersion called once per package (no root)
+      expect(writeVersion).toHaveBeenCalledTimes(2)
+      expect(writeVersion).toHaveBeenCalledWith(`${mockCwd}/packages/ui`, '9.2.0-canary.abc1234.0', false)
+      expect(writeVersion).toHaveBeenCalledWith(`${mockCwd}/packages/config`, '1.2.1-canary.abc1234.0', false)
+    })
+
+    it('Then calls confirmBump with independent versionMode for canary independent mode', async () => {
+      vi.mocked(loadRelizyConfig).mockResolvedValueOnce({
+        cwd: mockCwd,
+        bump: {
+          type: 'release',
+          yes: false,
+        },
+        release: { clean: false },
+        monorepo: {
+          versionMode: 'independent',
+          packages: ['packages/*'],
+        },
+        types: {
+          feat: { title: 'Features', semver: 'minor' },
+        },
+        templates: { tagBody: '{{newVersion}}' },
+        logLevel: 'default',
+      } as unknown as ResolvedRelizyConfig)
+
+      vi.mocked(getShortCommitSha).mockReturnValueOnce('abc1234')
+
+      vi.mocked(getPackages).mockResolvedValueOnce([
+        {
+          name: 'pkg-a',
+          version: '2.0.0',
+          path: `${mockCwd}/packages/pkg-a`,
+          newVersion: '2.1.0',
+          reason: 'commits',
+          commits: [createMockCommit('feat', 'add feature')],
+          fromTag: 'pkg-a@2.0.0',
+          dependencies: [],
+          private: false,
+        },
+      ])
+
+      vi.mocked(determineSemverChange).mockReturnValueOnce('minor')
+      vi.mocked(getCanaryVersion).mockReturnValueOnce('2.1.0-canary.abc1234.0')
+
+      await bump({
+        canary: true,
+      })
+
+      expect(confirmBump).toHaveBeenCalledWith(
+        expect.objectContaining({
+          versionMode: 'independent',
+          force: false,
+        }),
+      )
+    })
   })
 })

--- a/src/commands/bump.ts
+++ b/src/commands/bump.ts
@@ -303,6 +303,19 @@ async function bumpCanaryMode({
 }): Promise<BumpResult> {
   logger.debug('Starting bump in canary mode')
 
+  // Branch early for independent mode — each package gets its own canary version
+  if (config.monorepo?.versionMode === 'independent') {
+    const sha = getShortCommitSha(config.cwd)
+    const packages = await getPackages({ config, suffix: undefined, force: false })
+
+    if (packages.length === 0) {
+      logger.debug('No packages to bump')
+      return { bumped: false }
+    }
+
+    return bumpCanaryIndependentMode({ config, dryRun, preid, sha, packages })
+  }
+
   const rootPackageBase = readPackageJson(config.cwd)
 
   if (!rootPackageBase) {
@@ -354,7 +367,7 @@ async function bumpCanaryMode({
   }
 
   // Override newVersion on each package with the canary version
-  const packagesWithCanaryVersion = packages.map(pkg => ({
+  const packagesWithCanaryVersion = packages.map((pkg: import('../types').PackageBase) => ({
     ...pkg,
     newVersion: canaryVersion,
   }))
@@ -394,11 +407,75 @@ async function bumpCanaryMode({
       commits,
       newVersion: canaryVersion,
     },
-    bumpedPackages: packages.map(pkg => ({
+    bumpedPackages: packages.map((pkg: import('../types').PackageBase) => ({
       ...pkg,
       oldVersion: pkg.version,
       newVersion: canaryVersion,
       fromTag: from,
+    })),
+  }
+}
+
+async function bumpCanaryIndependentMode({
+  config,
+  dryRun,
+  preid,
+  sha,
+  packages,
+}: {
+  config: ResolvedRelizyConfig
+  dryRun: boolean
+  preid: string
+  sha: string
+  packages: import('../types').PackageBase[]
+}): Promise<BumpResult> {
+  logger.debug('Starting canary bump in independent mode')
+
+  const typesConfig = config.types as Record<string, { title: string, semver?: import('changelogen').SemverBumpType }>
+
+  // Compute per-package canary versions based on each package's own version and commits
+  const packagesWithCanaryVersion = packages.map((pkg) => {
+    const releaseType = determineSemverChange(pkg.commits, typesConfig)
+
+    const canaryVersion = getCanaryVersion({
+      currentVersion: pkg.version,
+      releaseType,
+      preid,
+      sha,
+    })
+
+    return {
+      ...pkg,
+      newVersion: canaryVersion,
+    }
+  })
+
+  if (!config.bump.yes) {
+    await confirmBump({
+      versionMode: 'independent',
+      config,
+      packages: packagesWithCanaryVersion,
+      force: false,
+      dryRun,
+    })
+  }
+  else {
+    for (const pkg of packagesWithCanaryVersion) {
+      logger.info(`${pkg.name}: ${pkg.version} → ${pkg.newVersion} (canary)`)
+    }
+  }
+
+  for (const pkg of packagesWithCanaryVersion) {
+    writeVersion(pkg.path, pkg.newVersion!, dryRun)
+  }
+
+  logger.info(`${dryRun ? '[dry-run] ' : ''}${packagesWithCanaryVersion.length} package(s) bumped independently (canary)`)
+
+  return {
+    bumped: true,
+    bumpedPackages: packagesWithCanaryVersion.map(pkg => ({
+      ...pkg,
+      oldVersion: pkg.version,
     })),
   }
 }


### PR DESCRIPTION
## Description

Fix canary mode with independant mode

## Type of Change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code style/UI update (formatting, renaming, etc; no functional changes)
- [ ] Refactor (no functional changes, code improvements)
- [ ] Documentation update
- [ ] Tests (adding missing tests or correcting existing tests)
- [ ] Build/CI related changes
- [ ] Dependencies update
- [ ] Performance improvements
- [ ] Other (please describe):

## Related Issues

- #51 
