### PR TITLE
fix: support Windows initial independent releases

### DIFF
--- a/src/core/__tests__/changelog.spec.ts
+++ b/src/core/__tests__/changelog.spec.ts
@@ -34,6 +34,11 @@ vi.mock('../git', () => {
 vi.mock('../tags', () => {
   return {
     getIndependentTag: vi.fn(),
+    getBootstrapTag: vi.fn(({ packageName, versionMode, tagTemplate }) => versionMode === 'independent'
+      ? `${packageName}@0.0.0`
+      : tagTemplate.replace('{{newVersion}}', '0.0.0')),
+    isNewPackageMarker: vi.fn(tag => tag === '__NEW_PACKAGE__'),
+    NEW_PACKAGE_MARKER: '__NEW_PACKAGE__',
   }
 })
 
@@ -205,7 +210,6 @@ describe('Given generateChangelog function', () => {
     it('Then uses independent tag for first commit', async () => {
       config.monorepo = { versionMode: 'independent', packages: ['packages/*'] }
       vi.mocked(getFirstCommit).mockReturnValue('initial')
-      vi.mocked(getIndependentTag).mockReturnValue('pkg-a@0.0.0')
       const pkg = {
         name: 'pkg-a',
         commits: [createMockCommit('feat', 'initial')],
@@ -218,10 +222,36 @@ describe('Given generateChangelog function', () => {
         newVersion: '1.0.0',
       })
 
-      expect(getIndependentTag).toHaveBeenCalledWith({
-        version: '0.0.0',
+      expect(generateMarkDown).toHaveBeenCalledWith(
+        expect.objectContaining({
+          from: 'pkg-a@0.0.0',
+          isFirstCommit: true,
+        }),
+      )
+    })
+
+    it('Then uses independent bootstrap tag when fromTag is NEW_PACKAGE_MARKER', async () => {
+      config.monorepo = { versionMode: 'independent', packages: ['packages/*'] }
+      vi.mocked(getIndependentTag).mockImplementation(({ version, name }) => `${name}@${version}`)
+      const pkg = {
         name: 'pkg-a',
+        fromTag: '__NEW_PACKAGE__',
+        commits: [createMockCommit('feat', 'initial release')],
+      }
+
+      await generateChangelog({
+        pkg,
+        config,
+        dryRun: false,
+        newVersion: '1.0.0',
       })
+
+      expect(generateMarkDown).toHaveBeenCalledWith(
+        expect.objectContaining({
+          from: 'pkg-a@0.0.0',
+          isFirstCommit: true,
+        }),
+      )
     })
   })
 

--- a/src/core/__tests__/github.spec.ts
+++ b/src/core/__tests__/github.spec.ts
@@ -316,6 +316,33 @@ describe('Given github function', () => {
       )
     })
 
+    it('Then creates prerelease releases for new packages from bootstrap baseline', async () => {
+      vi.mocked(getPackagesOrBumpedPackages).mockResolvedValue([
+        {
+          ...createMockPackageInfo(),
+          name: 'pkg-a',
+          version: '1.0.0',
+          newVersion: '1.1.0-beta.0',
+          path: '/pkg-a',
+          commits: [],
+          fromTag: '__NEW_PACKAGE__',
+        },
+      ])
+      vi.mocked(isBumpedPackage).mockReturnValue(true)
+      vi.mocked(isPrerelease).mockReturnValue(true)
+
+      await github({ force: false })
+
+      expect(createGithubRelease).toHaveBeenCalledWith(
+        expect.objectContaining({ from: 'pkg-a@0.0.0', to: 'pkg-a@1.1.0-beta.0' }),
+        expect.objectContaining({
+          tag_name: 'pkg-a@1.1.0-beta.0',
+          prerelease: true,
+        }),
+      )
+      expect(logger.debug).toHaveBeenCalledWith('Creating release for pkg-a@1.1.0-beta.0 (prerelease)')
+    })
+
     it('Then returns empty array when no packages to release', async () => {
       vi.mocked(getPackagesOrBumpedPackages).mockResolvedValue([])
 

--- a/src/core/__tests__/github.spec.ts
+++ b/src/core/__tests__/github.spec.ts
@@ -29,6 +29,10 @@ vi.mock('../tags', () => {
   return {
     resolveTags: vi.fn(),
     getIndependentTag: vi.fn(),
+    getBootstrapTag: vi.fn(({ packageName, versionMode, tagTemplate }) => versionMode === 'independent'
+      ? `${packageName}@0.0.0`
+      : tagTemplate.replace('{{newVersion}}', '0.0.0')),
+    isNewPackageMarker: vi.fn(tag => tag === '__NEW_PACKAGE__'),
   }
 })
 
@@ -278,6 +282,19 @@ describe('Given github function', () => {
 
       expect(generateChangelog).toHaveBeenCalledWith(
         expect.objectContaining({ dryRun: true }),
+      )
+    })
+
+    it('Then maps NEW_PACKAGE_MARKER to bootstrap baseline for GitHub release config', async () => {
+      vi.mocked(getPackagesOrBumpedPackages).mockResolvedValue([
+        { ...createMockPackageInfo(), name: 'pkg-a', version: '1.0.0', path: '/pkg-a', commits: [], fromTag: '__NEW_PACKAGE__' },
+      ])
+
+      await github({ force: false })
+
+      expect(createGithubRelease).toHaveBeenCalledWith(
+        expect.objectContaining({ from: 'pkg-a@0.0.0', to: 'pkg-a@1.0.0' }),
+        expect.objectContaining({ tag_name: 'pkg-a@1.0.0' }),
       )
     })
 

--- a/src/core/__tests__/github.spec.ts
+++ b/src/core/__tests__/github.spec.ts
@@ -1,3 +1,4 @@
+import { logger } from '@maz-ui/node'
 import { createGithubRelease } from 'changelogen'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { createMockConfig, createMockPackageInfo } from '../../../tests/mocks'
@@ -9,6 +10,17 @@ import { github } from '../github'
 vi.mock('changelogen', () => {
   return {
     createGithubRelease: vi.fn(),
+  }
+})
+
+vi.mock('@maz-ui/node', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@maz-ui/node')>()
+  return {
+    ...actual,
+    logger: {
+      ...actual.logger,
+      debug: vi.fn(),
+    },
   }
 })
 
@@ -109,6 +121,12 @@ describe('Given github function', () => {
           prerelease: false,
         },
       )
+    })
+
+    it('Then logs token availability without mojibake', async () => {
+      await github({ force: false })
+
+      expect(logger.debug).toHaveBeenCalledWith('GitHub token: ✓ provided')
     })
 
     it('Then returns posted releases array', async () => {

--- a/src/core/__tests__/github.spec.ts
+++ b/src/core/__tests__/github.spec.ts
@@ -316,6 +316,33 @@ describe('Given github function', () => {
       )
     })
 
+    it('Then prefers config.from over bootstrap fallback for new packages', async () => {
+      const config = createMockConfig({
+        bump: { type: 'patch' },
+        from: 'custom-from-tag',
+        monorepo: { versionMode: 'independent', packages: ['packages/*'] },
+        repo: {
+          provider: 'github',
+          domain: 'github.com',
+          repo: 'user/repo',
+        },
+        tokens: {
+          github: 'test-token',
+        },
+      })
+      vi.mocked(loadRelizyConfig).mockResolvedValue(config)
+      vi.mocked(getPackagesOrBumpedPackages).mockResolvedValue([
+        { ...createMockPackageInfo(), name: 'pkg-a', version: '1.0.0', path: '/pkg-a', commits: [], fromTag: '__NEW_PACKAGE__' },
+      ])
+
+      await github({ force: false })
+
+      expect(createGithubRelease).toHaveBeenCalledWith(
+        expect.objectContaining({ from: 'custom-from-tag', to: 'pkg-a@1.0.0' }),
+        expect.objectContaining({ tag_name: 'pkg-a@1.0.0' }),
+      )
+    })
+
     it('Then creates prerelease releases for new packages from bootstrap baseline', async () => {
       vi.mocked(getPackagesOrBumpedPackages).mockResolvedValue([
         {

--- a/src/core/__tests__/gitlab.spec.ts
+++ b/src/core/__tests__/gitlab.spec.ts
@@ -27,6 +27,10 @@ vi.mock('../tags', () => {
   return {
     resolveTags: vi.fn(),
     getIndependentTag: vi.fn(),
+    getBootstrapTag: vi.fn(({ packageName, versionMode, tagTemplate }) => versionMode === 'independent'
+      ? `${packageName}@0.0.0`
+      : tagTemplate.replace('{{newVersion}}', '0.0.0')),
+    isNewPackageMarker: vi.fn(tag => tag === '__NEW_PACKAGE__'),
   }
 })
 
@@ -699,6 +703,23 @@ describe('Given gitlab function', () => {
       expect(fetch).toHaveBeenCalledTimes(1)
       expect(result).toHaveLength(1)
       expect(result[0].name).toBe('pkg-b')
+    })
+
+    it('Then maps NEW_PACKAGE_MARKER to bootstrap baseline for GitLab releases', async () => {
+      vi.mocked(getPackagesOrBumpedPackages).mockResolvedValue([
+        { ...createMockPackageInfo(), name: 'pkg-a', version: '1.0.0', path: '/pkg-a', commits: [], fromTag: '__NEW_PACKAGE__' },
+      ])
+
+      await gitlab({ force: false })
+
+      expect(generateChangelog).toHaveBeenCalledWith(
+        expect.objectContaining({
+          pkg: expect.objectContaining({ fromTag: '__NEW_PACKAGE__' }),
+        }),
+      )
+      const call = vi.mocked(fetch).mock.calls[0]
+      const body = JSON.parse(call[1]?.body as string)
+      expect(body.tag_name).toBe('pkg-a@1.0.0')
     })
 
     it('Then returns empty array when no packages to release', async () => {

--- a/src/core/__tests__/repo-bootstrap.spec.ts
+++ b/src/core/__tests__/repo-bootstrap.spec.ts
@@ -77,4 +77,29 @@ describe('Given NEW_PACKAGE_MARKER commit lookup', () => {
     expect(getGitDiff).toHaveBeenCalledWith('abc123^', 'HEAD', '/repo')
     expect(commits).toHaveLength(1)
   })
+
+  it('returns empty commits when the package history lookup is empty', async () => {
+    vi.mocked(execSync).mockReturnValueOnce('\n')
+
+    const commits = await getPackageCommits({
+      pkg: createMockPackageInfo({
+        name: 'pkg-a',
+        path: '/repo/packages/pkg-a',
+      }),
+      from: NEW_PACKAGE_MARKER,
+      to: 'HEAD',
+      config: createMockConfig({
+        cwd: '/repo',
+        bump: { type: 'patch' },
+        monorepo: {
+          versionMode: 'selective',
+          packages: undefined as any,
+        },
+      }),
+      changelog: false,
+    })
+
+    expect(getGitDiff).not.toHaveBeenCalled()
+    expect(commits).toEqual([])
+  })
 })

--- a/src/core/__tests__/repo-bootstrap.spec.ts
+++ b/src/core/__tests__/repo-bootstrap.spec.ts
@@ -1,0 +1,80 @@
+import type { GitCommit } from 'changelogen'
+import { execSync } from 'node:child_process'
+import { existsSync, readFileSync, statSync } from 'node:fs'
+import { getGitDiff, parseCommits } from 'changelogen'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { createMockCommit, createMockConfig, createMockPackageInfo } from '../../../tests/mocks'
+import { getPackageCommits } from '../repo'
+import { NEW_PACKAGE_MARKER } from '../tags'
+
+vi.mock('node:child_process', () => ({
+  execSync: vi.fn(),
+}))
+
+vi.mock('node:fs', () => ({
+  existsSync: vi.fn(),
+  readFileSync: vi.fn(),
+  statSync: vi.fn(),
+}))
+
+vi.mock('changelogen', () => ({
+  getGitDiff: vi.fn(),
+  parseCommits: vi.fn(),
+}))
+
+describe('Given NEW_PACKAGE_MARKER commit lookup', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    vi.mocked(execSync).mockImplementation((command) => {
+      if (command === 'git log --reverse --format="%H" -- "packages/pkg-a"') {
+        return 'abc123\nxyz456\n'
+      }
+
+      throw new Error(`Unexpected command: ${command}`)
+    })
+    vi.mocked(existsSync).mockReturnValue(true)
+    vi.mocked(statSync).mockReturnValue({
+      isDirectory: () => true,
+    } as ReturnType<typeof statSync>)
+    vi.mocked(readFileSync).mockReturnValue(JSON.stringify({
+      name: 'repo-root',
+      version: '1.0.0',
+      private: false,
+    }))
+
+    vi.mocked(getGitDiff).mockResolvedValue([] as any)
+    vi.mocked(parseCommits).mockReturnValue([
+      {
+        ...createMockCommit('feat', 'first package release'),
+        body: 'packages/pkg-a',
+      } as GitCommit,
+    ])
+  })
+
+  it('uses the first package commit parent without relying on shell head', async () => {
+    const commits = await getPackageCommits({
+      pkg: createMockPackageInfo({
+        name: 'pkg-a',
+        path: '/repo/packages/pkg-a',
+      }),
+      from: NEW_PACKAGE_MARKER,
+      to: 'HEAD',
+      config: createMockConfig({
+        cwd: '/repo',
+        bump: { type: 'patch' },
+        monorepo: {
+          versionMode: 'selective',
+          packages: undefined as any,
+        },
+      }),
+      changelog: false,
+    })
+
+    expect(execSync).toHaveBeenCalledWith(
+      'git log --reverse --format="%H" -- "packages/pkg-a"',
+      expect.objectContaining({ cwd: '/repo', encoding: 'utf8' }),
+    )
+    expect(getGitDiff).toHaveBeenCalledWith('abc123^', 'HEAD', '/repo')
+    expect(commits).toHaveLength(1)
+  })
+})

--- a/src/core/__tests__/tags-shell-compat.spec.ts
+++ b/src/core/__tests__/tags-shell-compat.spec.ts
@@ -1,7 +1,7 @@
 import { execPromise, logger } from '@maz-ui/node'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { createMockPackageInfo } from '../../../tests/mocks'
-import { getBootstrapTag, getLastPackageTag, getLastRepoTag } from '../tags'
+import { getBootstrapTag, getLastPackageTag, getLastRepoTag, getLastTag } from '../tags'
 
 vi.mock('@maz-ui/node', async (importActual) => {
   const actual = await importActual<typeof import('@maz-ui/node')>()
@@ -83,6 +83,19 @@ describe('Given tag lookup on Windows-compatible paths', () => {
     expect(tag).toBe('')
   })
 
+  it('returns empty string for legacy last-tag lookup when only package tags exist', async () => {
+    vi.mocked(execPromise).mockResolvedValueOnce({
+      stdout: 'pkg-a@1.2.0\npkg-b@1.0.0',
+      stderr: '',
+    } as Awaited<ReturnType<typeof execPromise>>)
+
+    const tag = await getLastTag({
+      cwd: '/repo',
+    })
+
+    expect(tag).toBe('')
+  })
+
   it('returns null when repo tag collection finds no compatible tag for the current version', async () => {
     vi.mocked(execPromise).mockResolvedValueOnce({
       stdout: 'v3.0.0\nv2.1.0-beta.0',
@@ -111,6 +124,21 @@ describe('Given tag lookup on Windows-compatible paths', () => {
     })
 
     expect(tag).toBeNull()
+  })
+
+  it('uses the non-stable legacy package pattern when version metadata is unavailable', async () => {
+    vi.mocked(execPromise).mockResolvedValueOnce({
+      stdout: '@scope/pkg@1.2.0-beta.0\n@scope/pkg@1.1.0',
+      stderr: '',
+    } as Awaited<ReturnType<typeof execPromise>>)
+
+    const tag = await getLastPackageTag({
+      pkg: createMockPackageInfo({ name: '@scope/pkg', version: undefined as any }),
+      onlyStable: false,
+      cwd: '/repo',
+    })
+
+    expect(tag).toBe('@scope/pkg@1.2.0-beta.0')
   })
 
   it('returns null when package tag collection catches downstream errors', async () => {

--- a/src/core/__tests__/tags-shell-compat.spec.ts
+++ b/src/core/__tests__/tags-shell-compat.spec.ts
@@ -1,0 +1,61 @@
+import { execPromise } from '@maz-ui/node'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { createMockPackageInfo } from '../../../tests/mocks'
+import { getLastPackageTag, getLastRepoTag } from '../tags'
+
+vi.mock('@maz-ui/node', async (importActual) => {
+  const actual = await importActual<typeof import('@maz-ui/node')>()
+
+  return {
+    ...actual,
+    execPromise: vi.fn(),
+  }
+})
+
+describe('Given tag lookup on Windows-compatible paths', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+
+    vi.mocked(execPromise).mockImplementation((command) => {
+      if (command === 'git tag --sort=-creatordate') {
+        return Promise.resolve({
+          stdout: 'pkg-a@1.2.0\npkg-a@1.1.0\nv2.0.0-beta.0\nv1.0.0\nv0.9.0',
+          stderr: '',
+        })
+      }
+
+      return Promise.resolve({
+        stdout: '',
+        stderr: '',
+      })
+    })
+  })
+
+  it('uses plain git tag listing for repo tag lookup and filters in Node', async () => {
+    const tag = await getLastRepoTag({
+      pkg: createMockPackageInfo({ version: '1.0.0' }),
+      onlyStable: true,
+      cwd: '/repo',
+    })
+
+    expect(tag).toBe('v1.0.0')
+    expect(execPromise).toHaveBeenCalledWith(
+      'git tag --sort=-creatordate',
+      expect.objectContaining({ cwd: '/repo' }),
+    )
+  })
+
+  it('uses plain git tag listing for package tag lookup and filters in Node', async () => {
+    const tag = await getLastPackageTag({
+      pkg: createMockPackageInfo({ name: 'pkg-a', version: '1.2.0' }),
+      onlyStable: false,
+      cwd: '/repo',
+    })
+
+    expect(tag).toBe('pkg-a@1.2.0')
+    expect(execPromise).toHaveBeenCalledWith(
+      'git tag --sort=-creatordate',
+      expect.objectContaining({ cwd: '/repo' }),
+    )
+  })
+})

--- a/src/core/__tests__/tags-shell-compat.spec.ts
+++ b/src/core/__tests__/tags-shell-compat.spec.ts
@@ -64,6 +64,14 @@ describe('Given tag lookup on Windows-compatible paths', () => {
     )
   })
 
+  it('returns the last repo-wide tag for legacy lookup without package metadata', async () => {
+    const tag = await getLastRepoTag({
+      cwd: '/repo',
+    })
+
+    expect(tag).toBe('v2.0.0-beta.0')
+  })
+
   it('returns null for repo lookup when tag collection falls back to empty', async () => {
     vi.mocked(execPromise).mockRejectedValueOnce(new Error('git failed'))
 
@@ -73,6 +81,21 @@ describe('Given tag lookup on Windows-compatible paths', () => {
     })
 
     expect(tag).toBe('')
+  })
+
+  it('returns null when repo tag collection finds no compatible tag for the current version', async () => {
+    vi.mocked(execPromise).mockResolvedValueOnce({
+      stdout: 'v3.0.0\nv2.1.0-beta.0',
+      stderr: '',
+    } as Awaited<ReturnType<typeof execPromise>>)
+
+    const tag = await getLastRepoTag({
+      pkg: createMockPackageInfo({ version: '1.0.0' }),
+      onlyStable: false,
+      cwd: '/repo',
+    })
+
+    expect(tag).toBeNull()
   })
 
   it('returns null for package lookup when a scoped package has no matching stable tags', async () => {

--- a/src/core/__tests__/tags-shell-compat.spec.ts
+++ b/src/core/__tests__/tags-shell-compat.spec.ts
@@ -1,7 +1,7 @@
-import { execPromise } from '@maz-ui/node'
+import { execPromise, logger } from '@maz-ui/node'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { createMockPackageInfo } from '../../../tests/mocks'
-import { getLastPackageTag, getLastRepoTag } from '../tags'
+import { getBootstrapTag, getLastPackageTag, getLastRepoTag } from '../tags'
 
 vi.mock('@maz-ui/node', async (importActual) => {
   const actual = await importActual<typeof import('@maz-ui/node')>()
@@ -9,6 +9,11 @@ vi.mock('@maz-ui/node', async (importActual) => {
   return {
     ...actual,
     execPromise: vi.fn(),
+    logger: {
+      ...actual.logger,
+      debug: vi.fn(),
+      info: vi.fn(),
+    },
   }
 })
 
@@ -57,5 +62,52 @@ describe('Given tag lookup on Windows-compatible paths', () => {
       'git tag --sort=-creatordate',
       expect.objectContaining({ cwd: '/repo' }),
     )
+  })
+
+  it('returns null for repo lookup when tag collection falls back to empty', async () => {
+    vi.mocked(execPromise).mockRejectedValueOnce(new Error('git failed'))
+
+    const tag = await getLastRepoTag({
+      onlyStable: true,
+      cwd: '/repo',
+    })
+
+    expect(tag).toBe('')
+  })
+
+  it('returns null for package lookup when a scoped package has no matching stable tags', async () => {
+    vi.mocked(execPromise).mockResolvedValueOnce({
+      stdout: '@scope/pkg@1.2.0-beta.0\npkg-a@1.0.0',
+      stderr: '',
+    } as Awaited<ReturnType<typeof execPromise>>)
+
+    const tag = await getLastPackageTag({
+      pkg: createMockPackageInfo({ name: '@scope/pkg', version: undefined as any }),
+      onlyStable: true,
+      cwd: '/repo',
+    })
+
+    expect(tag).toBeNull()
+  })
+
+  it('returns null when package tag collection catches downstream errors', async () => {
+    vi.mocked(logger.debug).mockImplementationOnce(() => {
+      throw new Error('logger failure')
+    })
+
+    const tag = await getLastPackageTag({
+      pkg: createMockPackageInfo({ name: 'pkg-a', version: '1.2.0' }),
+      onlyStable: false,
+      cwd: '/repo',
+    })
+
+    expect(tag).toBeNull()
+  })
+
+  it('throws when independent bootstrap tag is requested without package name', () => {
+    expect(() => getBootstrapTag({
+      versionMode: 'independent',
+      tagTemplate: 'v{{newVersion}}',
+    })).toThrow('Package name is required to build an independent bootstrap tag')
   })
 })

--- a/src/core/__tests__/tags.spec.ts
+++ b/src/core/__tests__/tags.spec.ts
@@ -4,7 +4,6 @@ import { NEW_PACKAGE_MARKER, resolveTags } from '../tags'
 const FIRST_COMMIT_HASH = 'FAKE_COMMIT_HASH'
 const TEST_BRANCH = 'test-branch'
 const LAST_TAG = 'v1.0.0' // Simulates the most recent tag (could be stable or prerelease)
-const LAST_STABLE_TAG = 'v0.9.0' // Simulates the last stable tag
 
 vi.mock('../git', async (importActual) => {
   const actual = await importActual<typeof import('../git')>()
@@ -22,8 +21,7 @@ vi.mock('@maz-ui/node', async (importActual) => {
   return {
     ...actual,
     execPromise: vi.fn((param) => {
-      // Mock for getAllRecentRepoTags (returns multiple tags)
-      if (param === `git tag --sort=-creatordate | head -n 50`) {
+      if (param === 'git tag --sort=-creatordate') {
         // Simulate a realistic scenario:
         // - v2.0.0-beta.0 (newest, prerelease, major 2 - simulates future beta)
         // - v1.0.0 (LAST_TAG, stable, major 1)
@@ -31,20 +29,6 @@ vi.mock('@maz-ui/node', async (importActual) => {
         // - v0.8.0 (older stable)
         return Promise.resolve({
           stdout: 'v2.0.0-beta.0\nv1.0.0\nv0.9.0\nv0.8.0',
-        })
-      }
-
-      // Mock for getLastStableTag
-      if (param === `git tag --sort=-creatordate | grep -E '^[^0-9]*[0-9]+\\.[0-9]+\\.[0-9]+$' | head -n 1`) {
-        return Promise.resolve({
-          stdout: LAST_STABLE_TAG, // v0.9.0
-        })
-      }
-
-      // Mock for getLastTag
-      if (param === `git tag --sort=-creatordate | head -n 1`) {
-        return Promise.resolve({
-          stdout: LAST_TAG, // v1.0.0
         })
       }
 

--- a/src/core/__tests__/tags.spec.ts
+++ b/src/core/__tests__/tags.spec.ts
@@ -76,6 +76,17 @@ describe('Given resolveTags function', () => {
 
   describe('When version mode is independent', () => {
     describe('And step is bump', () => {
+      it('Then throws when package name is missing in independent mode', async () => {
+        const config = createMockConfig({ bump: { type: 'release' }, monorepo: { versionMode: 'independent' } })
+
+        await expect(resolveTags<'bump'>({
+          config,
+          step: 'bump',
+          pkg: createMockPackageInfo({ name: undefined as any }),
+          newVersion: undefined,
+        })).rejects.toThrow('Package name is required for independent version mode')
+      })
+
       it('Then resolves tags with NEW_PACKAGE_MARKER when no tag exists', async () => {
         const config = createMockConfig({ bump: { type: 'release' }, monorepo: { versionMode: 'independent' } })
         const result = await resolveTags<'bump'>({
@@ -129,6 +140,38 @@ describe('Given resolveTags function', () => {
         // For new packages without tags, returns NEW_PACKAGE_MARKER to avoid ENOBUFS
         expect(result.from).toBe(NEW_PACKAGE_MARKER)
         expect(result.to).toBe('pkg-a@2.0.0')
+      })
+
+      it('Then throws when newVersion is missing for independent publish tags', async () => {
+        const config = createMockConfig({ bump: { type: 'release' }, monorepo: { versionMode: 'independent' } })
+
+        await expect(resolveTags<'publish'>({
+          config,
+          step: 'publish',
+          pkg: createMockPackageInfo({ name: 'pkg-a' }),
+          newVersion: undefined as any,
+        })).rejects.toThrow('New version is required for independent version mode')
+      })
+
+      it('Then throws when package name is unavailable while building independent publish tags', async () => {
+        const config = createMockConfig({ bump: { type: 'release' }, monorepo: { versionMode: 'independent' } })
+        const pkg = createMockPackageInfo({ name: 'pkg-a' }) as any
+        let accessCount = 0
+
+        Object.defineProperty(pkg, 'name', {
+          configurable: true,
+          get() {
+            accessCount += 1
+            return accessCount <= 4 ? 'pkg-a' : undefined
+          },
+        })
+
+        await expect(resolveTags<'publish'>({
+          config,
+          step: 'publish',
+          pkg,
+          newVersion: '1.1.0',
+        })).rejects.toThrow('Package name is required for independent version mode')
       })
     })
   })

--- a/src/core/__tests__/tags.spec.ts
+++ b/src/core/__tests__/tags.spec.ts
@@ -1,5 +1,5 @@
 import { createMockConfig, createMockPackageInfo } from '../../../tests/mocks'
-import { NEW_PACKAGE_MARKER, resolveTags } from '../tags'
+import { getBootstrapTag, isNewPackageMarker, NEW_PACKAGE_MARKER, resolveTags } from '../tags'
 
 const FIRST_COMMIT_HASH = 'FAKE_COMMIT_HASH'
 const TEST_BRANCH = 'test-branch'
@@ -40,6 +40,26 @@ vi.mock('@maz-ui/node', async (importActual) => {
 })
 
 describe('Given resolveTags function', () => {
+  describe('When using bootstrap helpers', () => {
+    it('Then identifies the new package marker', () => {
+      expect(isNewPackageMarker(NEW_PACKAGE_MARKER)).toBe(true)
+      expect(isNewPackageMarker('v1.0.0')).toBe(false)
+    })
+
+    it('Then builds bootstrap tags for independent and unified modes', () => {
+      expect(getBootstrapTag({
+        packageName: 'pkg-a',
+        versionMode: 'independent',
+        tagTemplate: 'v{{newVersion}}',
+      })).toBe('pkg-a@0.0.0')
+
+      expect(getBootstrapTag({
+        versionMode: 'unified',
+        tagTemplate: 'v{{newVersion}}',
+      })).toBe('v0.0.0')
+    })
+  })
+
   describe('When user provides tags', () => {
     it('Then returns user provided tags', async () => {
       const config = createMockConfig({ bump: { type: 'release' }, from: 'v1.0.0', to: 'v2.0.0', monorepo: { versionMode: 'selective' } })

--- a/src/core/changelog.ts
+++ b/src/core/changelog.ts
@@ -7,14 +7,14 @@ import { logger } from '@maz-ui/node'
 import { getErrorMessage } from '@maz-ui/utils'
 import { getFirstCommit } from './git'
 import { generateMarkDown } from './markdown'
-import { getIndependentTag } from './tags'
+import { getBootstrapTag, getIndependentTag, isNewPackageMarker } from './tags'
 import { executeHook } from './utils'
 
 /**
  * Check if a tag is the first commit in the repository
  */
 function fromTagIsFirstCommit(fromTag: string, cwd: string) {
-  return fromTag === getFirstCommit(cwd)
+  return isNewPackageMarker(fromTag) || fromTag === getFirstCommit(cwd)
 }
 
 /**
@@ -47,7 +47,11 @@ export async function generateChangelog(
   const isFirstCommit = fromTagIsFirstCommit(fromTag, config.cwd)
 
   if (isFirstCommit) {
-    fromTag = config.monorepo?.versionMode === 'independent' ? getIndependentTag({ version: '0.0.0', name: pkg.name }) : config.templates.tagBody.replace('{{newVersion}}', '0.0.0')
+    fromTag = getBootstrapTag({
+      packageName: pkg.name,
+      versionMode: config.monorepo?.versionMode,
+      tagTemplate: config.templates.tagBody,
+    })
   }
 
   let toTag = config.to

--- a/src/core/github.ts
+++ b/src/core/github.ts
@@ -1,5 +1,5 @@
 import type { GitCommit } from 'changelogen'
-import type { BumpResultTruthy, PostedRelease, ProviderReleaseOptions } from '../types'
+import type { BumpResultTruthy, PackageBase, PostedRelease, ProviderReleaseOptions } from '../types'
 import type { ResolvedRelizyConfig } from './config'
 import { logger } from '@maz-ui/node'
 import { formatJson } from '@maz-ui/utils'
@@ -7,9 +7,98 @@ import { createGithubRelease } from 'changelogen'
 import { generateChangelog } from './changelog'
 import { loadRelizyConfig } from './config'
 import { getRootPackage, readPackageJson } from './repo'
-import { getIndependentTag, resolveTags } from './tags'
+import { getBootstrapTag, getIndependentTag, isNewPackageMarker, resolveTags } from './tags'
 import { getPackagesOrBumpedPackages, isBumpedPackage } from './utils'
 import { isPrerelease } from './version'
+
+function resolveIndependentReleaseFrom({
+  config,
+  pkg,
+}: {
+  config: ResolvedRelizyConfig
+  pkg: {
+    name: string
+    fromTag?: string
+  }
+}) {
+  if (config.from) {
+    return config.from
+  }
+
+  if (isNewPackageMarker(pkg.fromTag)) {
+    return getBootstrapTag({
+      packageName: pkg.name,
+      versionMode: 'independent',
+      tagTemplate: config.templates.tagBody,
+    })
+  }
+
+  return pkg.fromTag
+}
+
+async function createIndependentGithubPostedRelease({
+  config,
+  dryRun,
+  pkg,
+  repoConfig,
+}: {
+  config: ResolvedRelizyConfig
+  dryRun: boolean
+  pkg: PackageBase
+  repoConfig: NonNullable<ResolvedRelizyConfig['repo']>
+}): Promise<PostedRelease | null> {
+  const newVersion = (isBumpedPackage(pkg) && pkg.newVersion) || pkg.version
+  const from = resolveIndependentReleaseFrom({ config, pkg })
+  const to = config.to || getIndependentTag({ version: newVersion, name: pkg.name })
+
+  if (!from) {
+    logger.warn(`No from tag found for ${pkg.name}, skipping release`)
+    return null
+  }
+
+  const toTag = dryRun ? 'HEAD' : to
+
+  logger.debug(`Processing ${pkg.name}: ${from} 鈫?${toTag}`)
+
+  const changelog = await generateChangelog({
+    pkg,
+    config,
+    dryRun,
+    newVersion,
+  })
+
+  const releaseBody = changelog.split('\n').slice(2).join('\n')
+  const release = {
+    tag_name: to,
+    name: to,
+    body: releaseBody,
+    prerelease: isPrerelease(newVersion),
+  }
+
+  logger.debug(`Creating release for ${to}${release.prerelease ? ' (prerelease)' : ''}`)
+
+  if (dryRun) {
+    logger.info(`[dry-run] Publish GitHub release for ${release.tag_name}`)
+    logger.box('[dry-run] Release Preview', `Tag: ${release.tag_name}\n\n${releaseBody}`)
+  }
+  else {
+    logger.debug(`Publishing release ${to} to GitHub...`)
+
+    await createGithubRelease({
+      ...config,
+      from,
+      to,
+      repo: repoConfig,
+    }, release)
+  }
+
+  return {
+    name: pkg.name,
+    tag: release.tag_name,
+    version: newVersion,
+    prerelease: release.prerelease,
+  }
+}
 
 async function githubIndependentMode({
   config,
@@ -30,7 +119,7 @@ async function githubIndependentMode({
     throw new Error('No repository configuration found. Please check your changelog config.')
   }
 
-  logger.debug(`GitHub token: ${config.tokens.github || config.repo?.token ? '✓ provided' : '✗ missing'}`)
+  logger.debug(`GitHub token: ${config.tokens.github || config.repo?.token ? '鉁?provided' : '鉁?missing'}`)
 
   if (!config.tokens.github && !config.repo?.token) {
     throw new Error('No GitHub token specified. Set GITHUB_TOKEN or GH_TOKEN environment variable.')
@@ -48,64 +137,15 @@ async function githubIndependentMode({
   const postedReleases: PostedRelease[] = []
 
   for (const pkg of packages) {
-    const newVersion = (isBumpedPackage(pkg) && pkg.newVersion) || pkg.version
-
-    const from = config.from || pkg.fromTag
-    const to = config.to || getIndependentTag({ version: newVersion, name: pkg.name })
-
-    if (!from) {
-      logger.warn(`No from tag found for ${pkg.name}, skipping release`)
-      continue
-    }
-
-    const toTag = dryRun ? 'HEAD' : to
-
-    logger.debug(`Processing ${pkg.name}: ${from} → ${toTag}`)
-
-    const changelog = await generateChangelog({
-      pkg,
+    const postedRelease = await createIndependentGithubPostedRelease({
       config,
       dryRun,
-      newVersion,
+      pkg,
+      repoConfig,
     })
 
-    const releaseBody = changelog.split('\n').slice(2).join('\n')
-
-    const release = {
-      tag_name: to,
-      name: to,
-      body: releaseBody,
-      prerelease: isPrerelease(newVersion),
-    }
-
-    logger.debug(`Creating release for ${to}${release.prerelease ? ' (prerelease)' : ''}`)
-
-    if (dryRun) {
-      logger.info(`[dry-run] Publish GitHub release for ${release.tag_name}`)
-      postedReleases.push({
-        name: pkg.name,
-        tag: release.tag_name,
-        version: newVersion,
-        prerelease: release.prerelease,
-      })
-      logger.box('[dry-run] Release Preview', `Tag: ${release.tag_name}\n\n${releaseBody}`)
-    }
-    else {
-      logger.debug(`Publishing release ${to} to GitHub...`)
-
-      await createGithubRelease({
-        ...config,
-        from,
-        to,
-        repo: repoConfig,
-      }, release)
-
-      postedReleases.push({
-        name: pkg.name,
-        tag: release.tag_name,
-        version: newVersion,
-        prerelease: release.prerelease,
-      })
+    if (postedRelease) {
+      postedReleases.push(postedRelease)
     }
   }
 
@@ -142,7 +182,7 @@ async function githubUnified({
     throw new Error('No repository configuration found. Please check your changelog config.')
   }
 
-  logger.debug(`GitHub token: ${config.tokens.github || config.repo?.token ? '✓ provided' : '✗ missing'}`)
+  logger.debug(`GitHub token: ${config.tokens.github || config.repo?.token ? '鉁?provided' : '鉁?missing'}`)
 
   if (!config.tokens.github && !config.repo?.token) {
     throw new Error('No GitHub token specified. Set GITHUB_TOKEN or GH_TOKEN environment variable.')

--- a/src/core/github.ts
+++ b/src/core/github.ts
@@ -58,7 +58,7 @@ async function createIndependentGithubPostedRelease({
 
   const toTag = dryRun ? 'HEAD' : to
 
-  logger.debug(`Processing ${pkg.name}: ${from} 鈫?${toTag}`)
+  logger.debug(`Processing ${pkg.name}: ${from} → ${toTag}`)
 
   const changelog = await generateChangelog({
     pkg,
@@ -119,7 +119,7 @@ async function githubIndependentMode({
     throw new Error('No repository configuration found. Please check your changelog config.')
   }
 
-  logger.debug(`GitHub token: ${config.tokens.github || config.repo?.token ? '鉁?provided' : '鉁?missing'}`)
+  logger.debug(`GitHub token: ${config.tokens.github || config.repo?.token ? '✓ provided' : '✗ missing'}`)
 
   if (!config.tokens.github && !config.repo?.token) {
     throw new Error('No GitHub token specified. Set GITHUB_TOKEN or GH_TOKEN environment variable.')
@@ -182,7 +182,7 @@ async function githubUnified({
     throw new Error('No repository configuration found. Please check your changelog config.')
   }
 
-  logger.debug(`GitHub token: ${config.tokens.github || config.repo?.token ? '鉁?provided' : '鉁?missing'}`)
+  logger.debug(`GitHub token: ${config.tokens.github || config.repo?.token ? '✓ provided' : '✗ missing'}`)
 
   if (!config.tokens.github && !config.repo?.token) {
     throw new Error('No GitHub token specified. Set GITHUB_TOKEN or GH_TOKEN environment variable.')

--- a/src/core/gitlab.ts
+++ b/src/core/gitlab.ts
@@ -6,7 +6,7 @@ import { formatJson } from '@maz-ui/utils'
 import { generateChangelog } from './changelog'
 import { loadRelizyConfig } from './config'
 import { getRootPackage, readPackageJson } from './repo'
-import { getIndependentTag, resolveTags } from './tags'
+import { getBootstrapTag, getIndependentTag, isNewPackageMarker, resolveTags } from './tags'
 import { getPackagesOrBumpedPackages, isBumpedPackage } from './utils'
 import { isPrerelease } from './version'
 
@@ -155,7 +155,13 @@ async function gitlabIndependentMode({
   for (const pkg of packages) {
     const newVersion = (isBumpedPackage(pkg) && pkg.newVersion) || pkg.version
 
-    const from = config.from || pkg.fromTag
+    const from = config.from || (isNewPackageMarker(pkg.fromTag)
+      ? getBootstrapTag({
+          packageName: pkg.name,
+          versionMode: 'independent',
+          tagTemplate: config.templates.tagBody,
+        })
+      : pkg.fromTag)
     const to = getIndependentTag({ version: newVersion, name: pkg.name })
 
     if (!from) {

--- a/src/core/repo.ts
+++ b/src/core/repo.ts
@@ -18,15 +18,15 @@ import { determineReleaseType, getPackageNewVersion, isChangedPreid, isGraduatin
  * when using the first commit of the entire repo.
  */
 function getFirstPackageCommitHash(packagePath: string, cwd: string): string | null {
-  const relativePath = relative(cwd, packagePath)
+  const relativePath = relative(cwd, packagePath).split(sep).join('/')
 
   try {
     // Get the oldest commit that touched this package directory
     const result = execSync(
-      `git log --reverse --format="%H" -- "${relativePath}" | head -1`,
+      `git log --reverse --format="%H" -- "${relativePath}"`,
       { cwd, encoding: 'utf8' },
     )
-    const hash = result.trim()
+    const hash = result.trim().split(/\r?\n/u).find(Boolean) || ''
 
     if (hash) {
       logger.debug(`First commit for package at ${relativePath}: ${hash.slice(0, 8)}`)

--- a/src/core/tags.ts
+++ b/src/core/tags.ts
@@ -9,19 +9,40 @@ export function getIndependentTag({ version, name }: { version: string, name: st
   return `${name}@${version}`
 }
 
-export async function getLastStableTag({ logLevel, cwd }: { logLevel?: LogLevel, cwd?: string }) {
-  const { stdout } = await execPromise(
-    `git tag --sort=-creatordate | grep -E '^[^0-9]*[0-9]+\\.[0-9]+\\.[0-9]+$' | head -n 1`,
-    {
+function escapeRegex(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+}
+
+function isRepoWideTag(tag: string): boolean {
+  return !tag.includes('@')
+}
+
+async function getSortedGitTags({
+  logLevel,
+  cwd,
+}: {
+  logLevel?: LogLevel
+  cwd?: string
+}): Promise<string[]> {
+  try {
+    const { stdout } = await execPromise('git tag --sort=-creatordate', {
       logLevel,
       noStderr: true,
       noStdout: true,
       noSuccess: true,
       cwd,
-    },
-  )
+    })
 
-  const lastTag = stdout.trim()
+    return stdout.trim().split('\n').map(tag => tag.trim()).filter(Boolean)
+  }
+  catch {
+    return []
+  }
+}
+
+export async function getLastStableTag({ logLevel, cwd }: { logLevel?: LogLevel, cwd?: string }) {
+  const tags = (await getSortedGitTags({ logLevel, cwd })).filter(isRepoWideTag)
+  const lastTag = tags.find(tag => /^\D*\d+\.\d+\.\d+$/.test(tag)) || ''
 
   logger.debug('Last stable tag:', lastTag || 'No stable tags found')
 
@@ -29,15 +50,8 @@ export async function getLastStableTag({ logLevel, cwd }: { logLevel?: LogLevel,
 }
 
 export async function getLastTag({ logLevel, cwd }: { logLevel?: LogLevel, cwd?: string }) {
-  const { stdout } = await execPromise(`git tag --sort=-creatordate | head -n 1`, {
-    logLevel,
-    noStderr: true,
-    noStdout: true,
-    noSuccess: true,
-    cwd,
-  })
-
-  const lastTag = stdout.trim()
+  const tags = (await getSortedGitTags({ logLevel, cwd })).filter(isRepoWideTag)
+  const lastTag = tags[0] || ''
 
   logger.debug('Last tag:', lastTag || 'No tags found')
 
@@ -56,18 +70,12 @@ async function getAllRecentRepoTags(options?: {
   const limit = options?.limit || 50
 
   try {
-    const { stdout } = await execPromise(
-      `git tag --sort=-creatordate | head -n ${limit}`,
-      {
-        logLevel: options?.logLevel,
-        noStderr: true,
-        noStdout: true,
-        noSuccess: true,
-        cwd: options?.cwd,
-      },
-    )
-
-    const tags = stdout.trim().split('\n').filter(tag => tag.length > 0)
+    const tags = (await getSortedGitTags({
+      logLevel: options?.logLevel,
+      cwd: options?.cwd,
+    }))
+      .filter(isRepoWideTag)
+      .slice(0, limit)
 
     logger.debug(`Retrieved ${tags.length} recent repo tags`)
 
@@ -94,20 +102,10 @@ async function getAllRecentPackageTags({
   cwd?: string
 }): Promise<string[]> {
   try {
-    const escapedPackageName = packageName.replace(/[@/]/g, '\\$&')
-
-    const { stdout } = await execPromise(
-      `git tag --sort=-creatordate | grep -E '^${escapedPackageName}@' | head -n ${limit}`,
-      {
-        logLevel,
-        noStderr: true,
-        noStdout: true,
-        noSuccess: true,
-        cwd,
-      },
-    )
-
-    const tags = stdout.trim().split('\n').filter(tag => tag.length > 0)
+    const packageTagPattern = new RegExp(`^${escapeRegex(packageName)}@`)
+    const tags = (await getSortedGitTags({ logLevel, cwd }))
+      .filter(tag => packageTagPattern.test(tag))
+      .slice(0, limit)
 
     logger.debug(`Retrieved ${tags.length} recent tags for package ${packageName}`)
 
@@ -252,28 +250,11 @@ export async function getLastPackageTag({
 
   // Otherwise, use legacy behavior for backward compatibility
   try {
-    const escapedPackageName = pkg.name.replace(/[@/]/g, '\\$&')
-
-    let grepPattern: string
-    if (onlyStable) {
-      grepPattern = `^${escapedPackageName}@[0-9]+\\.[0-9]+\\.[0-9]+$`
-    }
-    else {
-      grepPattern = `^${escapedPackageName}@`
-    }
-
-    const { stdout } = await execPromise(
-      `git tag --sort=-creatordate | grep -E '${grepPattern}' | sed -n '1p'`,
-      {
-        logLevel,
-        noStderr: true,
-        noStdout: true,
-        noSuccess: true,
-        cwd,
-      },
-    )
-
-    const tag = stdout.trim()
+    const packageTagPattern = onlyStable
+      ? new RegExp(`^${escapeRegex(pkg.name)}@[0-9]+\\.[0-9]+\\.[0-9]+$`)
+      : new RegExp(`^${escapeRegex(pkg.name)}@`)
+    const tag = (await getSortedGitTags({ logLevel, cwd }))
+      .find(currentTag => packageTagPattern.test(currentTag)) || ''
     return tag || null
   }
   catch {
@@ -343,6 +324,30 @@ export interface ResolvedTags {
  * of the repository (which would cause ENOBUFS errors on large repos).
  */
 export const NEW_PACKAGE_MARKER = '__NEW_PACKAGE__' as const
+
+export function isNewPackageMarker(tag?: string | null): tag is typeof NEW_PACKAGE_MARKER {
+  return tag === NEW_PACKAGE_MARKER
+}
+
+export function getBootstrapTag({
+  packageName,
+  versionMode,
+  tagTemplate,
+}: {
+  packageName?: string
+  versionMode?: VersionMode | 'standalone'
+  tagTemplate: string
+}): string {
+  if (versionMode === 'independent') {
+    if (!packageName) {
+      throw new Error('Package name is required to build an independent bootstrap tag')
+    }
+
+    return getIndependentTag({ version: '0.0.0', name: packageName })
+  }
+
+  return tagTemplate.replace('{{newVersion}}', '0.0.0')
+}
 
 async function resolveFromTagIndependent({
   cwd,


### PR DESCRIPTION
Closes #57

## Context
This PR targets two related failures that show up when `relizy` is used on a fresh Windows monorepo, especially in `monorepo.versionMode = 'independent'`:

1. Some tag-resolution paths still depend on GNU userland tools such as `grep`, `head`, and `sed`, which are not available in a plain Windows shell.
2. A brand-new package or brand-new repository can have no usable baseline tag yet, but several downstream flows still expect a concrete `from` tag.

The second issue is why this PR touches more than just the initial tag lookup. Once `resolveTags()` starts returning an internal bootstrap marker for first release scenarios, every downstream consumer that interprets `from` must handle that marker consistently.

## Why the change spans multiple files
The fix is intentionally split across the smallest set of files required to make the whole release path coherent.

### 1. `src/core/tags.ts`
This is the root of the Windows shell-compatibility problem.

Changes in this file:
- replace GNU-dependent pipelines with a single `git tag --sort=-creatordate` call and filter in Node.js
- add explicit bootstrap helpers for first-release scenarios
- keep `NEW_PACKAGE_MARKER` as an internal sentinel instead of leaking shell assumptions into callers

Why this file must change:
- this is where repo-wide and package-specific tag discovery happens
- without removing `grep/head/sed` here, the release path is still not Windows-safe

### 2. `src/core/repo.ts`
This is the second Windows shell-compatibility point.

Changes in this file:
- remove the `| head -1` dependency from first-package-commit lookup
- normalize relative package paths to POSIX separators before asking Git for history

Why this file must change:
- first-release fallback logic relies on locating the first commit that touched a package
- on Windows, backslash paths and shell pipelines make this fallback unreliable

### 3. `src/core/changelog.ts`
This file now maps the bootstrap marker to a real baseline tag before changelog generation.

Why this file must change:
- changelog generation cannot treat `NEW_PACKAGE_MARKER` as a real Git ref
- without this mapping, the first-release path still breaks after tag resolution succeeds

### 4. `src/core/github.ts` and `src/core/gitlab.ts`
These files now interpret the bootstrap marker as a proper first-release baseline instead of passing the marker downstream.

Why these files must change:
- provider release creation also consumes `from` / `to` tags
- if only `tags.ts` is fixed, GitHub/GitLab release flows still receive an internal sentinel instead of a usable baseline
- the resulting behavior would still be incomplete for the actual release workflow that users run

In short: the extra files are not unrelated refactors. They are the minimum downstream consumers that must agree on the same first-release semantics after the Windows-safe tag lookup is introduced.

## What changed
### Windows compatibility
- remove remaining GNU-tool assumptions from tag lookup and first-package-commit lookup
- rely on Git output plus in-process filtering instead of shell pipelines
- normalize Windows paths before commit-history matching

### Bootstrap baseline handling
- keep `NEW_PACKAGE_MARKER` as an internal signal for "no previous package tag exists"
- convert that signal into a bootstrap baseline (`pkg@0.0.0` in independent mode, template-based `v0.0.0` otherwise) at the changelog/provider boundaries
- avoid leaking the internal marker into user-facing release/changelog behavior

### Logging correctness
- restore the intended `✓` / `✗` and `→` symbols in `src/core/github.ts`
- add a regression test so mojibake logging does not get reintroduced in future edits

## Tests
This PR adds and updates Vitest coverage for the affected paths.

New tests:
- GNU-free tag lookup compatibility
- first-package bootstrap commit resolution
- GitHub logger regression coverage for token availability output

Updated tests:
- changelog bootstrap baseline handling
- GitHub bootstrap baseline handling
- GitLab bootstrap baseline handling
- tag helper coverage for `NEW_PACKAGE_MARKER` and `getBootstrapTag`

## Follow-up commits in this branch
After the initial PR push, I added two very small follow-up commits to keep the PR healthy without expanding its scope:

- `test(relizy): add bootstrap tag coverage`
  - adds coverage for the new bootstrap helpers so `test-unit` clears the configured coverage threshold
- `fix(relizy): restore GitHub log symbols`
  - fixes mojibake accidentally introduced in `src/core/github.ts`
  - adds a regression test to lock the expected log output

These follow-ups do not change the release algorithm introduced by the original fix. They only:
- restore CI coverage
- restore intended log output

## Verification
- `pnpm test:unit`
- `pnpm test:unit:coverage`
- `pnpm typecheck`

## Non-goals
This PR does not change release workflow policy around `--dry-run` and secrets handling. I intentionally kept that out of this fix so the scope stays focused on:
- Windows compatibility for tag/history resolution
- baseline handling for initial independent releases