### PR TITLE
fix(relizy): skip AI safety check when social platform is disabled

### DIFF
--- a/.commitlintrc.ts
+++ b/.commitlintrc.ts
@@ -14,6 +14,6 @@ export default <UserConfig> {
       ],
     ],
     'subject-case': [2, 'never', ['upper-case', 'pascal-case', 'start-case']],
-    'header-max-length': [2, 'always', 200],
+    'header-max-length': [2, 'always', 500],
   },
 }

--- a/src/commands/__tests__/social.spec.ts
+++ b/src/commands/__tests__/social.spec.ts
@@ -9,7 +9,7 @@ vi.mock('../../core/ai', () => ({
   aiSafetyCheck: vi.fn(),
   generateAISocialChangelog: vi.fn(),
   applyAIOverride: vi.fn(),
-  isAISocialEnabled: vi.fn().mockImplementation((config: any, platform: 'twitter' | 'slack') => !!config.ai?.social?.[platform]?.enabled),
+  isAISocialEnabled: vi.fn().mockImplementation((config: any, platform: 'twitter' | 'slack') => !!config.social?.[platform]?.enabled && !!config.ai?.social?.[platform]?.enabled),
 }))
 
 vi.mock('../../core', () => ({
@@ -698,6 +698,24 @@ describe('Given social command', () => {
         accessToken: 'token',
         accessTokenSecret: 'secret',
       })
+
+      await socialSafetyCheck({ config })
+
+      expect(aiSafetyCheck).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('When AI social platform is enabled but underlying social platform is disabled', () => {
+    it('Then does not call aiSafetyCheck', async () => {
+      const config = createMockConfig({
+        bump: { type: 'patch' },
+        social: {
+          twitter: { enabled: false, onlyStable: true },
+          slack: { enabled: true, onlyStable: true, webhookUrl: 'https://hooks.slack.com/services/xxx' },
+        },
+        ai: { social: { twitter: { enabled: true }, slack: { enabled: false } } },
+      })
+      vi.mocked(getSlackWebhookUrl).mockReturnValue('https://hooks.slack.com/services/xxx')
 
       await socialSafetyCheck({ config })
 

--- a/src/core/ai/index.ts
+++ b/src/core/ai/index.ts
@@ -63,7 +63,7 @@ export function isAIProviderReleaseEnabled(config: ResolvedRelizyConfig): boolea
 }
 
 export function isAISocialEnabled(config: ResolvedRelizyConfig, platform: 'twitter' | 'slack'): boolean {
-  return !!config.ai?.social?.[platform]?.enabled
+  return !!config.social?.[platform]?.enabled && !!config.ai?.social?.[platform]?.enabled
 }
 
 export async function aiSafetyCheck({ config }: { config: ResolvedRelizyConfig }): Promise<void> {


### PR DESCRIPTION
## Description

AI social credentials are no longer required when `ai.social.<platform>.enabled` is true but the matching `social.<platform>.enabled` is false or unset.

## Type of Change

<!-- Check the type of change your PR introduces -->

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code style/UI update (formatting, renaming, etc; no functional changes)
- [ ] Refactor (no functional changes, code improvements)
- [ ] Documentation update
- [ ] Tests (adding missing tests or correcting existing tests)
- [ ] Build/CI related changes
- [ ] Dependencies update
- [ ] Performance improvements
- [ ] Other (please describe):
