### PR TITLE
fix: fall back to last prerelease tag when no stable tag exists

### DIFF
--- a/src/core/__tests__/tags.spec.ts
+++ b/src/core/__tests__/tags.spec.ts
@@ -127,6 +127,64 @@ describe('Given resolveTags function', () => {
         expect(result.from).toBe(NEW_PACKAGE_MARKER)
         expect(result.to).toBe('pkg-a@2.0.0')
       })
+
+      it('Then falls back to last prerelease tag when only prerelease tags exist for the package', async () => {
+        // Real-world scenario: previous release left git tags only at @pkg/action@0.1.0-beta.{1..6}
+        // because `git push --follow-tags` failed, then package.json was manually bumped to 0.1.0
+        // to match what was published on npm. Without the fallback, the package would be flagged
+        // as __NEW_PACKAGE__ even though its tag history is intact.
+        vi.mocked(execPromise).mockResolvedValueOnce({
+          stdout: 'pkg-a@0.1.0-beta.6\npkg-a@0.1.0-beta.5\npkg-a@0.1.0-beta.4',
+        } as any)
+
+        const config = createMockConfig({ bump: { type: 'release' }, monorepo: { versionMode: 'independent' } })
+        const result = await resolveTags<'changelog'>({
+          config,
+          step: 'changelog',
+          pkg: createMockPackageInfo({ name: 'pkg-a', version: '0.1.0' }),
+          newVersion: '0.2.0-beta.0',
+        })
+
+        expect(result.from).toBe('pkg-a@0.1.0-beta.6')
+        expect(result.to).toBe(TEST_BRANCH)
+      })
+
+      it('Then prefers a stable tag over a prerelease when both exist for the package', async () => {
+        // Sanity check: the fallback should NOT kick in when a stable tag is available.
+        vi.mocked(execPromise).mockResolvedValueOnce({
+          stdout: 'pkg-a@0.1.0-beta.6\npkg-a@0.1.0\npkg-a@0.1.0-beta.5',
+        } as any)
+
+        const config = createMockConfig({ bump: { type: 'release' }, monorepo: { versionMode: 'independent' } })
+        const result = await resolveTags<'changelog'>({
+          config,
+          step: 'changelog',
+          pkg: createMockPackageInfo({ name: 'pkg-a', version: '0.1.0' }),
+          newVersion: '0.2.0-beta.0',
+        })
+
+        expect(result.from).toBe('pkg-a@0.1.0')
+        expect(result.to).toBe(TEST_BRANCH)
+      })
+
+      it('Then does not fall back to a prerelease tag from a higher major', async () => {
+        // Major-compatibility filter must still apply during the fallback: if every
+        // prerelease tag is from a future major (e.g. tags at 2.x while we are on 1.x),
+        // we treat the package as new rather than rewinding to an incompatible major.
+        vi.mocked(execPromise).mockResolvedValueOnce({
+          stdout: 'pkg-a@2.0.0-beta.0\npkg-a@2.0.0-beta.1',
+        } as any)
+
+        const config = createMockConfig({ bump: { type: 'release' }, monorepo: { versionMode: 'independent' } })
+        const result = await resolveTags<'changelog'>({
+          config,
+          step: 'changelog',
+          pkg: createMockPackageInfo({ name: 'pkg-a', version: '1.0.0' }),
+          newVersion: '1.0.1',
+        })
+
+        expect(result.from).toBe(NEW_PACKAGE_MARKER)
+      })
     })
   })
 
@@ -196,6 +254,27 @@ describe('Given resolveTags function', () => {
         })
 
         expect(result).toEqual({ from: NEW_PACKAGE_MARKER, to: TEST_BRANCH })
+      })
+
+      it('Then falls back to last prerelease repo tag when only prereleases exist (failed previous tag push)', async () => {
+        // Same scenario as the independent-mode test but at the repo level: tags only at
+        // v0.1.0-beta.{1..6} because the prior release left them un-pushed, package.json
+        // was manually bumped to 0.1.0. We should resume from the most recent prerelease
+        // tag instead of treating the package as new and skipping its history entirely.
+        vi.mocked(execPromise).mockResolvedValueOnce({
+          stdout: 'v0.1.0-beta.6\nv0.1.0-beta.5\nv0.1.0-beta.4',
+        } as any)
+
+        const config = createMockConfig({ bump: { type: 'release' }, monorepo: { versionMode: 'unified' } })
+        const result = await resolveTags<'changelog'>({
+          config,
+          step: 'changelog',
+          pkg: createMockPackageInfo({ version: '0.1.0', path: '/some/cwd/packages/pkg-a' }),
+          newVersion: '0.2.0-beta.0',
+        })
+
+        expect(result.from).toBe('v0.1.0-beta.6')
+        expect(result.to).toBe(TEST_BRANCH)
       })
 
       it('Then falls back to first commit for the root package when no compatible tag exists (fresh repo)', async () => {

--- a/src/core/tags.ts
+++ b/src/core/tags.ts
@@ -193,6 +193,12 @@ export function getLastRepoTag(options?: {
  * 2. Filters out prerelease tags if onlyStable is true
  * 3. Filters out tags with major version > current version
  * 4. Returns the most recent compatible tag
+ *
+ * If onlyStable removes every candidate but the repo has prerelease tags with a
+ * compatible major (e.g. previous `git push --follow-tags` failed and only beta
+ * tags remain on disk while package.json was bumped manually to a stable
+ * version), falls back to the most recent major-compatible tag rather than
+ * treating the repo as if it had no history.
  */
 async function getLastRepoTagWithFiltering({
   pkg,
@@ -218,15 +224,30 @@ async function getLastRepoTagWithFiltering({
     onlyStable,
   })
 
-  if (compatibleTags.length === 0) {
-    logger.info(`No compatible tags found for version ${pkg.version}`)
-    return null
+  if (compatibleTags.length > 0) {
+    const lastTag = compatibleTags[0]
+    logger.debug(`Last compatible repo tag: ${lastTag}`)
+    return lastTag
   }
 
-  const lastTag = compatibleTags[0]
-  logger.debug(`Last compatible repo tag: ${lastTag}`)
+  if (onlyStable) {
+    const prereleaseFallback = filterCompatibleTags({
+      tags: recentTags,
+      pkg,
+      onlyStable: false,
+    })
 
-  return lastTag
+    if (prereleaseFallback.length > 0) {
+      const fallbackTag = prereleaseFallback[0]
+      logger.info(
+        `No stable repo tag found for version ${pkg.version}, falling back to last prerelease tag: ${fallbackTag}`,
+      )
+      return fallbackTag
+    }
+  }
+
+  logger.info(`No compatible tags found for version ${pkg.version}`)
+  return null
 }
 
 export async function getLastPackageTag({
@@ -288,6 +309,12 @@ export async function getLastPackageTag({
  * 2. Filters out prerelease tags if onlyStable is true
  * 3. Filters out tags with major version > current version
  * 4. Returns the most recent compatible tag
+ *
+ * If onlyStable removes every candidate but the package has prerelease tags
+ * with a compatible major (e.g. previous `git push --follow-tags` failed and
+ * only beta tags exist while package.json was bumped manually to a stable
+ * version), falls back to the most recent major-compatible tag rather than
+ * marking the package as new.
  */
 async function getLastPackageTagWithFiltering({
   pkg,
@@ -318,15 +345,30 @@ async function getLastPackageTagWithFiltering({
     onlyStable,
   })
 
-  if (compatibleTags.length === 0) {
-    logger.info(`No compatible tags found for package ${pkg.name} with version ${pkg.version}`)
-    return null
+  if (compatibleTags.length > 0) {
+    const lastTag = compatibleTags[0]
+    logger.debug(`Last compatible package tag for ${pkg.name}: ${lastTag}`)
+    return lastTag
   }
 
-  const lastTag = compatibleTags[0]
-  logger.debug(`Last compatible package tag for ${pkg.name}: ${lastTag}`)
+  if (onlyStable) {
+    const prereleaseFallback = filterCompatibleTags({
+      tags: recentTags,
+      pkg,
+      onlyStable: false,
+    })
 
-  return lastTag
+    if (prereleaseFallback.length > 0) {
+      const fallbackTag = prereleaseFallback[0]
+      logger.info(
+        `No stable tags found for package ${pkg.name} with version ${pkg.version}, falling back to last prerelease tag: ${fallbackTag}`,
+      )
+      return fallbackTag
+    }
+  }
+
+  logger.info(`No compatible tags found for package ${pkg.name} with version ${pkg.version}`)
+  return null
 }
 
 export type Step = 'bump' | 'changelog' | 'publish' | 'provider-release' | 'social'


### PR DESCRIPTION
## Summary
- Fix `__NEW_PACKAGE__` regression when only prerelease tags exist for a package/repo (typical after a failed `git push --follow-tags` followed by a manual bump of `package.json` to match what was published on npm).
- `getLastPackageTagWithFiltering` (independent mode) and `getLastRepoTagWithFiltering` (unified/selective mode) now fall back to the most recent major-compatible prerelease tag when `onlyStable` filters out every candidate, instead of treating the package as new.
- Major-compatibility filter still applies during fallback: a tag from a higher major is never picked.

## Test plan
- [x] `pnpm test:unit -- src/core/__tests__/tags.spec.ts` (1243 tests pass, 4 new)
- [x] `pnpm typecheck`
- [x] `pnpm lint`
- [ ] Manual: run a dry-run release on a repo where only beta tags exist for a package whose `package.json` was bumped to a stable version, verify the changelog uses the last beta tag as `from` instead of `__NEW_PACKAGE__`.