### PR TITLE
feat: support publishing to multiple registries

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ Imagine you have multiple packages in your project (like a box with several toys
 - 🔗 Automatic dependency bumping for workspace dependencies
 - 🐙 GitHub, GitLab & Bitbucket support
 - 🔐 2FA/OTP support for npm publishing
-- 🎛️ Custom registry support (private registries, GitHub Packages, etc.)
+- 🎛️ Custom registry support (private registries, GitHub Packages, etc.), with optional mirroring/routing to multiple registries (Nexus, JFrog, etc.)
 - ⚙️ Multiple configuration files support for different release workflows
 - 🔧 Support for npm, yarn, pnpm, and bun (auto-detected)
 - 📱 Social media integration (Twitter & Slack) for release announcements

--- a/docs/src/api/publish.md
+++ b/docs/src/api/publish.md
@@ -21,6 +21,12 @@ function publish(options?: PublishOptions): Promise<void>
 ```ts
 interface PublishOptions {
   registry?: string
+  /**
+   * Additional registries to publish to, on top of `registry`. See the
+   * [publish config reference](../config/publish.md#registries) for details.
+   * @default undefined
+   */
+  registries?: RegistryTarget[]
   tag?: string
   access?: 'public' | 'restricted'
   otp?: string

--- a/docs/src/config/publish.md
+++ b/docs/src/config/publish.md
@@ -132,6 +132,77 @@ export default defineConfig({
 You can also configure the token in the `tokens.registry` field or via environment variables: `NPM_TOKEN`, `RELIZY_NPM_TOKEN`, or `NODE_AUTH_TOKEN`.
 :::
 
+## registries
+
+Publish to additional registries, on top of the one configured via `registry` (e.g. `https://registry.npmjs.org`). Each entry can be scoped to specific packages with a glob pattern matched against the package name; entries without a `packages` filter are mirrored to every publishable package.
+
+This is fully opt-in and additive: leaving `registries` unset keeps the exact single-registry behavior described above.
+
+- **Type:** `RegistryTarget[]`
+
+```ts
+interface RegistryTarget {
+  name?: string // label used in logs, e.g. 'nexus'
+  registry: string // registry URL
+  token?: string
+  tag?: string
+  access?: 'public' | 'restricted'
+  otp?: string
+  packages?: string[] // glob patterns - omitted = applies to every package
+}
+```
+
+### Mirroring to every package
+
+```ts
+import { defineConfig } from 'relizy'
+
+export default defineConfig({
+  publish: {
+    registry: 'https://registry.npmjs.org',
+    registries: [
+      {
+        name: 'nexus',
+        registry: 'https://nexus.mycompany.com/repository/npm-internal/',
+        token: process.env.NEXUS_TOKEN,
+      },
+    ],
+  },
+})
+```
+
+Every package is published to `https://registry.npmjs.org` **and** to the internal Nexus registry.
+
+### Routing specific packages to a registry
+
+```ts
+import { defineConfig } from 'relizy'
+
+export default defineConfig({
+  publish: {
+    registry: 'https://registry.npmjs.org',
+    registries: [
+      {
+        name: 'jfrog-internal',
+        registry: 'https://mycompany.jfrog.io/artifactory/api/npm/npm-internal/',
+        token: process.env.JFROG_TOKEN,
+        packages: ['@internal/*'],
+      },
+    ],
+  },
+})
+```
+
+Here, only packages whose name matches `@internal/*` are additionally published to the JFrog registry; every package still goes to the default `registry`.
+
+::: tip Authentication safety check
+When `publish.safetyCheck` is enabled, Relizy authenticates against every distinct registry declared in `registry` and `registries` before publishing starts (not just the ones matching a given package), so a misconfigured registry fails fast rather than mid-release.
+:::
+
+::: tip Failure behavior
+Publishing is fail-fast: if a package fails to publish to any of its resolved registries, the whole release stops immediately - it does not continue publishing the remaining registries or packages.
+:::
+
 ## safetyCheck
 
 Enable or disable the safety check before publishing. When enabled, Relizy will verify that the required tokens are set.
@@ -184,6 +255,13 @@ export default defineConfig({
     packages: ['packages/*'],
     buildCmd: 'pnpm build',
     token: process.env.NPM_TOKEN,
+    registries: [
+      {
+        name: 'nexus',
+        registry: 'https://nexus.mycompany.com/repository/npm-internal/',
+        token: process.env.NEXUS_TOKEN,
+      },
+    ],
     safetyCheck: true,
     safetyCheckTimeout: 15000,
   },

--- a/docs/src/config/publish.md
+++ b/docs/src/config/publish.md
@@ -149,6 +149,7 @@ interface RegistryTarget {
   access?: 'public' | 'restricted'
   otp?: string
   packages?: string[] // glob patterns - omitted = applies to every package
+  exclusive?: boolean // skip the default `registry` for matching packages
 }
 ```
 
@@ -195,12 +196,37 @@ export default defineConfig({
 
 Here, only packages whose name matches `@internal/*` are additionally published to the JFrog registry; every package still goes to the default `registry`.
 
+### Excluding the default registry for specific packages
+
+By default, entries in `registries` are purely additive: a matching package is published to that registry **on top of** the default `registry`. Set `exclusive: true` on an entry when matching packages should be published **only** to it (and any other matching registry), and never to the default one:
+
+```ts
+import { defineConfig } from 'relizy'
+
+export default defineConfig({
+  publish: {
+    registry: 'https://registry.npmjs.org',
+    registries: [
+      {
+        name: 'jfrog-internal',
+        registry: 'https://mycompany.jfrog.io/artifactory/api/npm/npm-internal/',
+        token: process.env.JFROG_TOKEN,
+        packages: ['@internal/*'],
+        exclusive: true,
+      },
+    ],
+  },
+})
+```
+
+Here, `@internal/*` packages are published **only** to the JFrog registry; every other package still goes to `https://registry.npmjs.org` as usual. `exclusive` only suppresses the default registry - it has no effect on other, non-exclusive `registries` entries that also match the package (they still apply).
+
 ::: tip Authentication safety check
-When `publish.safetyCheck` is enabled, Relizy authenticates against every distinct registry declared in `registry` and `registries` before publishing starts (not just the ones matching a given package), so a misconfigured registry fails fast rather than mid-release.
+When `publish.safetyCheck` is enabled, Relizy authenticates against every distinct registry declared in `registry` and `registries` before publishing starts (including the default registry, even if some packages ultimately exclude it), so a misconfigured registry fails fast rather than mid-release.
 :::
 
-::: tip Failure behavior
-Publishing is fail-fast: if a package fails to publish to any of its resolved registries, the whole release stops immediately - it does not continue publishing the remaining registries or packages.
+::: tip Failure behavior is fail-fast, not atomic
+If a package fails to publish to one of its resolved registries, Relizy stops immediately: no further registry or package is attempted. This bounds how much of a broken release can happen, but publishing to a single package's multiple registries is **not transactional** - if a package already succeeded on registry A and then fails on registry B, A's publish is not rolled back.
 :::
 
 ## safetyCheck

--- a/docs/src/config/publish.md
+++ b/docs/src/config/publish.md
@@ -222,7 +222,7 @@ export default defineConfig({
 Here, `@internal/*` packages are published **only** to the JFrog registry; every other package still goes to `https://registry.npmjs.org` as usual. `exclusive` only suppresses the default registry - it has no effect on other, non-exclusive `registries` entries that also match the package (they still apply).
 
 ::: tip Authentication safety check
-When `publish.safetyCheck` is enabled, Relizy authenticates against every distinct registry declared in `registry` and `registries` before publishing starts (including the default registry, even if some packages ultimately exclude it), so a misconfigured registry fails fast rather than mid-release.
+When `publish.safetyCheck` is enabled, Relizy authenticates against every distinct registry actually needed by the packages being published this release (including the default registry, even if some of those packages exclude it via `exclusive`), so a misconfigured registry fails fast rather than mid-release. A `registries` entry scoped to packages that are not part of this release (via `packages`) is **not** checked, so it cannot block an unrelated release.
 :::
 
 ::: tip Failure behavior is fail-fast, not atomic

--- a/docs/src/config/publish.md
+++ b/docs/src/config/publish.md
@@ -134,7 +134,7 @@ You can also configure the token in the `tokens.registry` field or via environme
 
 ## registries
 
-Publish to additional registries, on top of the one configured via `registry` (e.g. `https://registry.npmjs.org`). Each entry can be scoped to specific packages with a glob pattern matched against the package name; entries without a `packages` filter are mirrored to every publishable package.
+Publish to additional registries, on top of the one configured via `registry` (e.g. `https://registry.npmjs.org`). Each entry can be scoped to specific packages with a glob pattern matched against the package name; entries without a `packageFilter` are mirrored to every publishable package.
 
 This is fully opt-in and additive: leaving `registries` unset keeps the exact single-registry behavior described above.
 
@@ -148,10 +148,14 @@ interface RegistryTarget {
   tag?: string
   access?: 'public' | 'restricted'
   otp?: string
-  packages?: string[] // glob patterns - omitted = applies to every package
+  packageFilter?: string[] // glob patterns - omitted = applies to every package
   exclusive?: boolean // skip the default `registry` for matching packages
 }
 ```
+
+::: tip Why `packageFilter` and not `packages`
+`publish.packages` (top-level) controls _which packages get published at all_. `RegistryTarget.packageFilter` is a different concern: it only routes already-publishable packages to this specific registry. Distinct names avoid confusing the two.
+:::
 
 ### Mirroring to every package
 
@@ -187,7 +191,7 @@ export default defineConfig({
         name: 'jfrog-internal',
         registry: 'https://mycompany.jfrog.io/artifactory/api/npm/npm-internal/',
         token: process.env.JFROG_TOKEN,
-        packages: ['@internal/*'],
+        packageFilter: ['@internal/*'],
       },
     ],
   },
@@ -211,7 +215,7 @@ export default defineConfig({
         name: 'jfrog-internal',
         registry: 'https://mycompany.jfrog.io/artifactory/api/npm/npm-internal/',
         token: process.env.JFROG_TOKEN,
-        packages: ['@internal/*'],
+        packageFilter: ['@internal/*'],
         exclusive: true,
       },
     ],
@@ -222,7 +226,7 @@ export default defineConfig({
 Here, `@internal/*` packages are published **only** to the JFrog registry; every other package still goes to `https://registry.npmjs.org` as usual. `exclusive` only suppresses the default registry - it has no effect on other, non-exclusive `registries` entries that also match the package (they still apply).
 
 ::: tip Authentication safety check
-When `publish.safetyCheck` is enabled, Relizy authenticates against every distinct registry actually needed by the packages being published this release (including the default registry, even if some of those packages exclude it via `exclusive`), so a misconfigured registry fails fast rather than mid-release. A `registries` entry scoped to packages that are not part of this release (via `packages`) is **not** checked, so it cannot block an unrelated release.
+When `publish.safetyCheck` is enabled, Relizy authenticates against every distinct registry actually needed by the packages being published this release (including the default registry, even if some of those packages exclude it via `exclusive`), so a misconfigured registry fails fast rather than mid-release. A `registries` entry scoped to packages that are not part of this release (via `packageFilter`) is **not** checked, so it cannot block an unrelated release.
 :::
 
 ::: tip Failure behavior is fail-fast, not atomic

--- a/package.json
+++ b/package.json
@@ -100,6 +100,7 @@
     "convert-gitmoji": "^0.1.5",
     "defu": "6.1.7",
     "fast-glob": "^3.3.2",
+    "micromatch": "^4.0.8",
     "node-fetch-native": "^1.6.7",
     "semver": "^7.8.3"
   },
@@ -110,6 +111,7 @@
     "@commitlint/types": "^21.0.1",
     "@maz-ui/eslint-config": "5.0.0-beta.25",
     "@slack/web-api": "7.16.0",
+    "@types/micromatch": "^4.0.10",
     "@types/node": "^25.9.2",
     "@types/semver": "^7.7.1",
     "@vitest/coverage-v8": "^4.1.8",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -35,6 +35,9 @@ importers:
       fast-glob:
         specifier: ^3.3.2
         version: 3.3.3
+      micromatch:
+        specifier: ^4.0.8
+        version: 4.0.8
       node-fetch-native:
         specifier: ^1.6.7
         version: 1.6.7
@@ -60,6 +63,9 @@ importers:
       '@slack/web-api':
         specifier: 7.16.0
         version: 7.16.0
+      '@types/micromatch':
+        specifier: ^4.0.10
+        version: 4.0.10
       '@types/node':
         specifier: ^25.9.2
         version: 25.9.2
@@ -1867,6 +1873,9 @@ packages:
     peerDependencies:
       eslint: ^9.0.0 || ^10.0.0
 
+  '@types/braces@3.0.5':
+    resolution: {integrity: sha512-SQFof9H+LXeWNz8wDe7oN5zu7ket0qwMu5vZubW4GCJ8Kkeh6nBWUz87+KTz/G3Kqsrp0j/W253XJb3KMEeg3w==}
+
   '@types/chai@5.2.3':
     resolution: {integrity: sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==}
 
@@ -1908,6 +1917,9 @@ packages:
 
   '@types/mdurl@2.0.0':
     resolution: {integrity: sha512-RGdgjQUZba5p6QEFAVx2OGb8rQDL/cPRG7GiedRzMcJ1tYnUANBncjbSB1NRGwbvjcPeikRABz2nshyPk1bhWg==}
+
+  '@types/micromatch@4.0.10':
+    resolution: {integrity: sha512-5jOhFDElqr4DKTrTEbnW8DZ4Hz5LRUEmyrGpCMrD/NphYv3nUnaF08xmSLx1rGGnyEs/kFnhiw6dCgcDqMr5PQ==}
 
   '@types/ms@2.1.0':
     resolution: {integrity: sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA==}
@@ -4311,10 +4323,6 @@ packages:
 
   picocolors@1.1.1:
     resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
-
-  picomatch@2.3.1:
-    resolution: {integrity: sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==}
-    engines: {node: '>=8.6'}
 
   picomatch@2.3.2:
     resolution: {integrity: sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==}
@@ -6840,6 +6848,8 @@ snapshots:
       estraverse: 5.3.0
       picomatch: 4.0.4
 
+  '@types/braces@3.0.5': {}
+
   '@types/chai@5.2.3':
     dependencies:
       '@types/deep-eql': 4.0.2
@@ -6879,6 +6889,10 @@ snapshots:
       '@types/unist': 2.0.11
 
   '@types/mdurl@2.0.0': {}
+
+  '@types/micromatch@4.0.10':
+    dependencies:
+      '@types/braces': 3.0.5
 
   '@types/ms@2.1.0': {}
 
@@ -6940,8 +6954,8 @@ snapshots:
 
   '@typescript-eslint/project-service@8.57.2(typescript@6.0.3)':
     dependencies:
-      '@typescript-eslint/tsconfig-utils': 8.58.2(typescript@6.0.3)
-      '@typescript-eslint/types': 8.58.2
+      '@typescript-eslint/tsconfig-utils': 8.61.0(typescript@6.0.3)
+      '@typescript-eslint/types': 8.61.0
       debug: 4.4.3
       typescript: 6.0.3
     transitivePeerDependencies:
@@ -9466,7 +9480,7 @@ snapshots:
   micromatch@4.0.8:
     dependencies:
       braces: 3.0.3
-      picomatch: 2.3.1
+      picomatch: 2.3.2
 
   mime-db@1.52.0: {}
 
@@ -9730,8 +9744,6 @@ snapshots:
   perfect-debounce@2.1.0: {}
 
   picocolors@1.1.1: {}
-
-  picomatch@2.3.1: {}
 
   picomatch@2.3.2: {}
 

--- a/src/commands/__tests__/publish.spec.ts
+++ b/src/commands/__tests__/publish.spec.ts
@@ -160,7 +160,7 @@ describe('Given publishSafetyCheck function', () => {
           registry: 'https://registry.npmjs.org/',
           registries: [
             { name: 'nexus', registry: 'https://nexus.internal/repo/' },
-            { name: 'jfrog', registry: 'https://jfrog.internal/repo/', packages: ['@scope/*'] },
+            { name: 'jfrog', registry: 'https://jfrog.internal/repo/', packageFilter: ['@scope/*'] },
           ],
         },
         safetyCheck: true,
@@ -234,7 +234,7 @@ describe('Given publishSafetyCheck function', () => {
           packageManager: 'npm',
           registry: 'https://registry.npmjs.org/',
           registries: [
-            { name: 'jfrog', registry: 'https://jfrog.internal/repo/', packages: ['@internal/*'] },
+            { name: 'jfrog', registry: 'https://jfrog.internal/repo/', packageFilter: ['@internal/*'] },
           ],
         },
         safetyCheck: true,
@@ -261,7 +261,7 @@ describe('Given publishSafetyCheck function', () => {
           packageManager: 'npm',
           registry: 'https://registry.npmjs.org/',
           registries: [
-            { name: 'jfrog', registry: 'https://jfrog.internal/repo/', packages: ['@internal/*'] },
+            { name: 'jfrog', registry: 'https://jfrog.internal/repo/', packageFilter: ['@internal/*'] },
           ],
         },
         safetyCheck: true,

--- a/src/commands/__tests__/publish.spec.ts
+++ b/src/commands/__tests__/publish.spec.ts
@@ -147,6 +147,81 @@ describe('Given publishSafetyCheck function', () => {
       expect(processExitSpy).not.toHaveBeenCalled()
     })
   })
+
+  describe('When multiple registries are configured', () => {
+    it('Then authenticates against every distinct registry, once each', async () => {
+      const config = createMockConfig({
+        bump: { type: 'patch' },
+        publish: {
+          safetyCheck: true,
+          private: false,
+          args: [],
+          packageManager: 'npm',
+          registry: 'https://registry.npmjs.org/',
+          registries: [
+            { name: 'nexus', registry: 'https://nexus.internal/repo/' },
+            { name: 'jfrog', registry: 'https://jfrog.internal/repo/', packages: ['@scope/*'] },
+          ],
+        },
+        safetyCheck: true,
+        release: { publish: true },
+      })
+      vi.mocked(execPromise).mockResolvedValue({ stdout: '', stderr: '' })
+
+      await publishSafetyCheck({ config })
+
+      expect(execPromise).toHaveBeenCalledTimes(3)
+      expect(execPromise).toHaveBeenNthCalledWith(1, expect.stringContaining('--registry https://registry.npmjs.org/'), expect.any(Object))
+      expect(execPromise).toHaveBeenNthCalledWith(2, expect.stringContaining('--registry https://nexus.internal/repo/'), expect.any(Object))
+      expect(execPromise).toHaveBeenNthCalledWith(3, expect.stringContaining('--registry https://jfrog.internal/repo/'), expect.any(Object))
+    })
+
+    it('Then deduplicates a registry declared both as legacy and explicit', async () => {
+      const config = createMockConfig({
+        bump: { type: 'patch' },
+        publish: {
+          safetyCheck: true,
+          private: false,
+          args: [],
+          packageManager: 'npm',
+          registry: 'https://registry.npmjs.org/',
+          registries: [
+            { name: 'duplicate', registry: 'https://registry.npmjs.org/' },
+          ],
+        },
+        safetyCheck: true,
+        release: { publish: true },
+      })
+      vi.mocked(execPromise).mockResolvedValue({ stdout: '', stderr: '' })
+
+      await publishSafetyCheck({ config })
+
+      expect(execPromise).toHaveBeenCalledTimes(1)
+    })
+
+    it('Then stops at the first failing registry (fail-fast)', async () => {
+      const config = createMockConfig({
+        bump: { type: 'patch' },
+        publish: {
+          safetyCheck: true,
+          private: false,
+          args: [],
+          packageManager: 'npm',
+          registry: 'https://registry.npmjs.org/',
+          registries: [
+            { name: 'nexus', registry: 'https://nexus.internal/repo/' },
+          ],
+        },
+        safetyCheck: true,
+        release: { publish: true },
+      })
+      vi.mocked(execPromise).mockRejectedValue(new Error('Auth failed'))
+
+      await expect(() => publishSafetyCheck({ config })).rejects.toThrow()
+
+      expect(execPromise).toHaveBeenCalledTimes(1)
+    })
+  })
 })
 
 describe('Given publish command', () => {

--- a/src/commands/__tests__/publish.spec.ts
+++ b/src/commands/__tests__/publish.spec.ts
@@ -222,6 +222,61 @@ describe('Given publishSafetyCheck function', () => {
       expect(execPromise).toHaveBeenCalledTimes(1)
     })
   })
+
+  describe('When the packages to publish are known', () => {
+    it('Then only checks registries actually needed by those packages, skipping unmatched scoped ones', async () => {
+      const config = createMockConfig({
+        bump: { type: 'patch' },
+        publish: {
+          safetyCheck: true,
+          private: false,
+          args: [],
+          packageManager: 'npm',
+          registry: 'https://registry.npmjs.org/',
+          registries: [
+            { name: 'jfrog', registry: 'https://jfrog.internal/repo/', packages: ['@internal/*'] },
+          ],
+        },
+        safetyCheck: true,
+        release: { publish: true },
+      })
+      vi.mocked(execPromise).mockResolvedValue({ stdout: '', stderr: '' })
+
+      // None of the packages being published this release match '@internal/*'.
+      const packages = [createMockPackageInfo({ name: 'public-pkg' })]
+
+      await publishSafetyCheck({ config, packages })
+
+      expect(execPromise).toHaveBeenCalledTimes(1)
+      expect(execPromise).toHaveBeenCalledWith(expect.stringContaining('--registry https://registry.npmjs.org/'), expect.any(Object))
+    })
+
+    it('Then checks a scoped registry when one of the packages being published matches it', async () => {
+      const config = createMockConfig({
+        bump: { type: 'patch' },
+        publish: {
+          safetyCheck: true,
+          private: false,
+          args: [],
+          packageManager: 'npm',
+          registry: 'https://registry.npmjs.org/',
+          registries: [
+            { name: 'jfrog', registry: 'https://jfrog.internal/repo/', packages: ['@internal/*'] },
+          ],
+        },
+        safetyCheck: true,
+        release: { publish: true },
+      })
+      vi.mocked(execPromise).mockResolvedValue({ stdout: '', stderr: '' })
+
+      const packages = [createMockPackageInfo({ name: '@internal/foo' })]
+
+      await publishSafetyCheck({ config, packages })
+
+      expect(execPromise).toHaveBeenCalledTimes(2)
+      expect(execPromise).toHaveBeenCalledWith(expect.stringContaining('--registry https://jfrog.internal/repo/'), expect.any(Object))
+    })
+  })
 })
 
 describe('Given publish command', () => {

--- a/src/commands/publish.ts
+++ b/src/commands/publish.ts
@@ -1,8 +1,67 @@
 import type { ResolvedRelizyConfig } from '../core'
-import type { PackageBase, PublishOptions, PublishResponse } from '../types'
+import type { PackageBase, PublishOptions, PublishResponse, RegistryTarget } from '../types'
 import { execPromise, logger } from '@maz-ui/node'
-import { executeBuildCmd, getAuthCommand, getIndependentTag, getPackagesToPublishInIndependentMode, getPackagesToPublishInSelectiveMode, loadRelizyConfig, publishPackage, readPackageJson, topologicalSort } from '../core'
+import { executeBuildCmd, getAuthCommand, getIndependentTag, getPackagesToPublishInIndependentMode, getPackagesToPublishInSelectiveMode, loadRelizyConfig, publishPackage, readPackageJson, resolveAllConfiguredRegistryTargets, topologicalSort } from '../core'
 import { executeHook, filterOutPrivatePackages, getPackagesOrBumpedPackages } from '../core/utils'
+
+/**
+ * Authenticate against a single registry target, enforcing the configured
+ * timeout and surfacing a clear error on timeout or failure.
+ */
+async function checkRegistryAuth({
+  config,
+  registryTarget,
+  registryLabel,
+}: {
+  config: ResolvedRelizyConfig
+  registryTarget: RegistryTarget
+  registryLabel: string
+}) {
+  const authCommand = getAuthCommand({
+    packageManager: config.publish.packageManager,
+    config,
+    registryTarget,
+    otp: registryTarget.otp,
+  })
+  const timeoutMs = config.publish.safetyCheckTimeout ?? 15000
+
+  // Warn the user if the registry is slow, so a multi-second wait does not look
+  // like a freeze. Fires well before the timeout and is always cleared after.
+  const patienceDelay = Math.min(5000, Math.floor(timeoutMs / 2))
+  const patienceTimer = setTimeout(() => {
+    logger.info(`The package registry is taking longer than expected to respond (will time out at ${Math.round(timeoutMs / 1000)}s)...`)
+  }, patienceDelay)
+
+  try {
+    logger.info(`Authenticating to package registry${registryLabel}...`)
+    // execPromise enforces the timeout, masks the token in its logs/errors,
+    // and kills the command on timeout (error.killed is then true).
+    await execPromise(authCommand, {
+      cwd: config.cwd,
+      timeout: timeoutMs,
+      noStdout: true,
+      noStderr: true,
+      noSuccess: true,
+      noError: true,
+      logLevel: config.logLevel,
+    })
+    logger.info(`Successfully authenticated to package registry${registryLabel}`)
+  }
+  catch (error) {
+    if ((error as { killed?: boolean })?.killed) {
+      throw new Error(
+        `Authentication to package registry${registryLabel} timed out after ${timeoutMs}ms. `
+        + 'The registry did not respond - check your network or registry access, '
+        + 'increase publish.safetyCheckTimeout, or skip this check with --no-safety-check.',
+        { cause: error },
+      )
+    }
+    throw new Error(`Failed to authenticate to package registry${registryLabel}`, { cause: error })
+  }
+  finally {
+    clearTimeout(patienceTimer)
+  }
+}
 
 export async function publishSafetyCheck({ config }: { config: ResolvedRelizyConfig }) {
   if (!config.safetyCheck || !config.release.publish || !config.publish.safetyCheck) {
@@ -19,48 +78,15 @@ export async function publishSafetyCheck({ config }: { config: ResolvedRelizyCon
     return
   }
 
-  const authCommand = getAuthCommand({
-    packageManager: config.publish.packageManager,
-    config,
-    otp: config.publish.otp,
-  })
-  const timeoutMs = config.publish.safetyCheckTimeout ?? 15000
+  const registryTargets = resolveAllConfiguredRegistryTargets(config)
+  const showRegistryLabel = registryTargets.length > 1
 
-  // Warn the user if the registry is slow, so a multi-second wait does not look
-  // like a freeze. Fires well before the timeout and is always cleared after.
-  const patienceDelay = Math.min(5000, Math.floor(timeoutMs / 2))
-  const patienceTimer = setTimeout(() => {
-    logger.info(`The package registry is taking longer than expected to respond (will time out at ${Math.round(timeoutMs / 1000)}s)...`)
-  }, patienceDelay)
+  for (const registryTarget of registryTargets) {
+    const registryLabel = showRegistryLabel
+      ? ` [${registryTarget.name ?? registryTarget.registry ?? 'default'}]`
+      : ''
 
-  try {
-    logger.info('Authenticating to package registry...')
-    // execPromise enforces the timeout, masks the token in its logs/errors,
-    // and kills the command on timeout (error.killed is then true).
-    await execPromise(authCommand, {
-      cwd: config.cwd,
-      timeout: timeoutMs,
-      noStdout: true,
-      noStderr: true,
-      noSuccess: true,
-      noError: true,
-      logLevel: config.logLevel,
-    })
-    logger.info('Successfully authenticated to package registry')
-  }
-  catch (error) {
-    if ((error as { killed?: boolean })?.killed) {
-      throw new Error(
-        `Authentication to package registry timed out after ${timeoutMs}ms. `
-        + 'The registry did not respond - check your network or registry access, '
-        + 'increase publish.safetyCheckTimeout, or skip this check with --no-safety-check.',
-        { cause: error },
-      )
-    }
-    throw new Error('Failed to authenticate to package registry', { cause: error })
-  }
-  finally {
-    clearTimeout(patienceTimer)
+    await checkRegistryAuth({ config, registryTarget, registryLabel })
   }
 }
 
@@ -74,6 +100,7 @@ export async function publish(options: Partial<PublishOptions> = {}) {
         access: options.access,
         otp: options.otp,
         registry: options.registry,
+        registries: options.registries,
         tag: options.tag,
         buildCmd: options.buildCmd,
         token: options.token,

--- a/src/commands/publish.ts
+++ b/src/commands/publish.ts
@@ -1,7 +1,7 @@
 import type { ResolvedRelizyConfig } from '../core'
 import type { PackageBase, PublishOptions, PublishResponse, RegistryTarget } from '../types'
 import { execPromise, logger } from '@maz-ui/node'
-import { executeBuildCmd, getAuthCommand, getIndependentTag, getPackagesToPublishInIndependentMode, getPackagesToPublishInSelectiveMode, loadRelizyConfig, publishPackage, readPackageJson, resolveAllConfiguredRegistryTargets, topologicalSort } from '../core'
+import { executeBuildCmd, getAuthCommand, getIndependentTag, getPackagesToPublishInIndependentMode, getPackagesToPublishInSelectiveMode, loadRelizyConfig, publishPackage, readPackageJson, resolveAllConfiguredRegistryTargets, resolveRegistryTargetsForPackages, topologicalSort } from '../core'
 import { executeHook, filterOutPrivatePackages, getPackagesOrBumpedPackages } from '../core/utils'
 
 /**
@@ -63,7 +63,7 @@ async function checkRegistryAuth({
   }
 }
 
-export async function publishSafetyCheck({ config }: { config: ResolvedRelizyConfig }) {
+export async function publishSafetyCheck({ config, packages }: { config: ResolvedRelizyConfig, packages?: PackageBase[] }) {
   if (!config.safetyCheck || !config.release.publish || !config.publish.safetyCheck) {
     logger.debug('Safety check disabled or publish disabled')
     return
@@ -78,7 +78,12 @@ export async function publishSafetyCheck({ config }: { config: ResolvedRelizyCon
     return
   }
 
-  const registryTargets = resolveAllConfiguredRegistryTargets(config)
+  // When the packages to publish are already known, only check the registries
+  // they actually need - a registry scoped to packages outside this release
+  // should not block it. Otherwise, conservatively check everything configured.
+  const registryTargets = packages
+    ? resolveRegistryTargetsForPackages(packages, config)
+    : resolveAllConfiguredRegistryTargets(config)
   const showRegistryLabel = registryTargets.length > 1
 
   for (const registryTarget of registryTargets) {
@@ -126,8 +131,6 @@ export async function publish(options: Partial<PublishOptions> = {}) {
 
   try {
     await executeHook('before:publish', config, dryRun)
-
-    await publishSafetyCheck({ config })
 
     const rootPackage = readPackageJson(config.cwd)
 
@@ -181,6 +184,10 @@ export async function publish(options: Partial<PublishOptions> = {}) {
       logger.fail('No packages need to be published')
       return
     }
+
+    // Only check the registries this specific set of packages actually needs -
+    // scoped `registries` entries for packages outside this release must not block it.
+    await publishSafetyCheck({ config, packages: publishedPackages })
 
     await executeBuildCmd({
       config,

--- a/src/commands/release.ts
+++ b/src/commands/release.ts
@@ -36,6 +36,7 @@ function getReleaseConfig(options: Partial<ReleaseOptions> = {}) {
         access: options.access,
         otp: options.otp,
         registry: options.registry,
+        registries: options.registries,
         tag: options.tag,
         buildCmd: options.buildCmd,
         token: options.publishToken,

--- a/src/core/__tests__/npm.spec.ts
+++ b/src/core/__tests__/npm.spec.ts
@@ -734,6 +734,68 @@ describe('Given resolveRegistryTargetsForPackage function', () => {
       expect(result[0]?.name).toBe('default')
     })
   })
+
+  describe('When a matching registry is marked exclusive', () => {
+    it('Then skips the default registry and publishes only to the matching registries', () => {
+      const config = createMockConfig({
+        bump: { type: 'patch' },
+        publish: {
+          private: false,
+          args: [],
+          registry: 'https://registry.npmjs.org/',
+          registries: [
+            { name: 'jfrog', registry: 'https://jfrog.internal/repo/', packages: ['@scope/*'], exclusive: true },
+          ],
+        },
+      })
+
+      const scopedPkg = { ...createMockPackageInfo(), name: '@scope/foo' }
+
+      const result = resolveRegistryTargetsForPackage(scopedPkg, config)
+
+      expect(result.map(t => t.name)).toEqual(['jfrog'])
+    })
+
+    it('Then still publishes non-matching packages to the default registry', () => {
+      const config = createMockConfig({
+        bump: { type: 'patch' },
+        publish: {
+          private: false,
+          args: [],
+          registry: 'https://registry.npmjs.org/',
+          registries: [
+            { name: 'jfrog', registry: 'https://jfrog.internal/repo/', packages: ['@scope/*'], exclusive: true },
+          ],
+        },
+      })
+
+      const result = resolveRegistryTargetsForPackage(pkg, config) // name: 'test-package'
+
+      expect(result.map(t => t.name)).toEqual(['default'])
+    })
+
+    it('Then keeps a non-exclusive global mirror alongside an exclusive scoped registry', () => {
+      const config = createMockConfig({
+        bump: { type: 'patch' },
+        publish: {
+          private: false,
+          args: [],
+          registry: 'https://registry.npmjs.org/',
+          registries: [
+            { name: 'nexus', registry: 'https://nexus.internal/repo/' },
+            { name: 'jfrog', registry: 'https://jfrog.internal/repo/', packages: ['@scope/*'], exclusive: true },
+          ],
+        },
+      })
+
+      const scopedPkg = { ...createMockPackageInfo(), name: '@scope/foo' }
+
+      const result = resolveRegistryTargetsForPackage(scopedPkg, config)
+
+      // exclusive only suppresses the *default* registry, not other explicit mirrors.
+      expect(result.map(t => t.name)).toEqual(['nexus', 'jfrog'])
+    })
+  })
 })
 
 describe('Given resolveAllConfiguredRegistryTargets function', () => {

--- a/src/core/__tests__/npm.spec.ts
+++ b/src/core/__tests__/npm.spec.ts
@@ -16,6 +16,8 @@ import {
   getPackagesToPublishInIndependentMode,
   getPackagesToPublishInSelectiveMode,
   publishPackage,
+  resolveAllConfiguredRegistryTargets,
+  resolveRegistryTargetsForPackage,
 } from '../npm'
 import { getIndependentTag, resolveTags } from '../tags'
 import { isInCI } from '../utils'
@@ -637,6 +639,130 @@ describe('Given getNpmRegistry function', () => {
   })
 })
 
+describe('Given resolveRegistryTargetsForPackage function', () => {
+  let pkg: PackageBase
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    pkg = { ...createMockPackageInfo(), name: 'test-package' }
+  })
+
+  describe('When only the legacy registry is configured', () => {
+    it('Then returns a single target built from the legacy fields', () => {
+      const config = createMockConfig({
+        bump: { type: 'patch' },
+        publish: { private: false, args: [], registry: 'https://registry.npmjs.org/', token: 'legacy-token', tag: 'latest' },
+      })
+
+      const result = resolveRegistryTargetsForPackage(pkg, config)
+
+      expect(result).toEqual([
+        { name: 'default', registry: 'https://registry.npmjs.org/', token: 'legacy-token', tag: 'latest', access: undefined, otp: undefined },
+      ])
+    })
+  })
+
+  describe('When an explicit registry has no packages filter', () => {
+    it('Then mirrors it to every package alongside the legacy registry', () => {
+      const config = createMockConfig({
+        bump: { type: 'patch' },
+        publish: {
+          private: false,
+          args: [],
+          registry: 'https://registry.npmjs.org/',
+          registries: [{ name: 'nexus', registry: 'https://nexus.internal/repo/', token: 'nexus-token' }],
+        },
+      })
+
+      const result = resolveRegistryTargetsForPackage(pkg, config)
+
+      expect(result.map(t => t.name)).toEqual(['default', 'nexus'])
+    })
+  })
+
+  describe('When an explicit registry is scoped with a packages glob', () => {
+    it('Then includes it only for a package matching the pattern', () => {
+      const config = createMockConfig({
+        bump: { type: 'patch' },
+        publish: {
+          private: false,
+          args: [],
+          registry: 'https://registry.npmjs.org/',
+          registries: [{ name: 'jfrog', registry: 'https://jfrog.internal/repo/', packages: ['@scope/*'] }],
+        },
+      })
+
+      const scopedPkg = { ...createMockPackageInfo(), name: '@scope/foo' }
+
+      const result = resolveRegistryTargetsForPackage(scopedPkg, config)
+
+      expect(result.map(t => t.name)).toEqual(['default', 'jfrog'])
+    })
+
+    it('Then excludes it for a package not matching the pattern', () => {
+      const config = createMockConfig({
+        bump: { type: 'patch' },
+        publish: {
+          private: false,
+          args: [],
+          registry: 'https://registry.npmjs.org/',
+          registries: [{ name: 'jfrog', registry: 'https://jfrog.internal/repo/', packages: ['@scope/*'] }],
+        },
+      })
+
+      const result = resolveRegistryTargetsForPackage(pkg, config)
+
+      expect(result.map(t => t.name)).toEqual(['default'])
+    })
+  })
+
+  describe('When an explicit registry duplicates the legacy registry URL', () => {
+    it('Then keeps only the first occurrence (legacy wins)', () => {
+      const config = createMockConfig({
+        bump: { type: 'patch' },
+        publish: {
+          private: false,
+          args: [],
+          registry: 'https://registry.npmjs.org/',
+          registries: [{ name: 'duplicate', registry: 'https://registry.npmjs.org/' }],
+        },
+      })
+
+      const result = resolveRegistryTargetsForPackage(pkg, config)
+
+      expect(result).toHaveLength(1)
+      expect(result[0]?.name).toBe('default')
+    })
+  })
+})
+
+describe('Given resolveAllConfiguredRegistryTargets function', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  describe('When registries mix global and scoped entries', () => {
+    it('Then returns every distinct registry regardless of package scoping', () => {
+      const config = createMockConfig({
+        bump: { type: 'patch' },
+        publish: {
+          private: false,
+          args: [],
+          registry: 'https://registry.npmjs.org/',
+          registries: [
+            { name: 'nexus', registry: 'https://nexus.internal/repo/' },
+            { name: 'jfrog', registry: 'https://jfrog.internal/repo/', packages: ['@scope/*'] },
+          ],
+        },
+      })
+
+      const result = resolveAllConfiguredRegistryTargets(config)
+
+      expect(result.map(t => t.name)).toEqual(['default', 'nexus', 'jfrog'])
+    })
+  })
+})
+
 describe('Given publishPackage function', () => {
   let config: ResolvedRelizyConfig
   let pkg: PackageBase
@@ -1207,6 +1333,98 @@ describe('Given publishPackage function', () => {
       })
 
       expect(writeFileSync).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('When multiple registries are configured', () => {
+    it('Then publishes to the legacy registry and every mirrored registry', async () => {
+      config.publish.registry = 'https://registry.npmjs.org/'
+      config.publish.registries = [
+        { name: 'nexus', registry: 'https://nexus.internal/repo/' },
+      ]
+
+      await publishPackage({
+        pkg,
+        config,
+        packageManager: 'npm',
+        dryRun: false,
+      })
+
+      expect(execPromise).toHaveBeenCalledTimes(2)
+      expect(execPromise).toHaveBeenNthCalledWith(1, expect.stringContaining('--registry https://registry.npmjs.org/'), expect.any(Object))
+      expect(execPromise).toHaveBeenNthCalledWith(2, expect.stringContaining('--registry https://nexus.internal/repo/'), expect.any(Object))
+    })
+
+    it('Then only publishes to a scoped registry matching the package name', async () => {
+      config.publish.registry = 'https://registry.npmjs.org/'
+      config.publish.registries = [
+        { name: 'jfrog', registry: 'https://jfrog.internal/repo/', packages: ['@scope/*'] },
+      ]
+
+      await publishPackage({
+        pkg, // name: 'test-package', does not match '@scope/*'
+        config,
+        packageManager: 'npm',
+        dryRun: false,
+      })
+
+      expect(execPromise).toHaveBeenCalledTimes(1)
+      expect(execPromise).toHaveBeenCalledWith(expect.stringContaining('--registry https://registry.npmjs.org/'), expect.any(Object))
+    })
+
+    it('Then publishes to a scoped registry when the package name matches', async () => {
+      pkg.name = '@scope/foo'
+      vi.mocked(getIndependentTag).mockReturnValue('@scope/foo@1.0.1')
+      config.publish.registry = 'https://registry.npmjs.org/'
+      config.publish.registries = [
+        { name: 'jfrog', registry: 'https://jfrog.internal/repo/', packages: ['@scope/*'] },
+      ]
+
+      await publishPackage({
+        pkg,
+        config,
+        packageManager: 'npm',
+        dryRun: false,
+      })
+
+      expect(execPromise).toHaveBeenCalledTimes(2)
+      expect(execPromise).toHaveBeenNthCalledWith(2, expect.stringContaining('--registry https://jfrog.internal/repo/'), expect.any(Object))
+    })
+
+    it('Then includes the registry name in the log when publishing to more than one', async () => {
+      const loggerSpy = vi.spyOn(logger, 'info')
+      config.publish.registry = 'https://registry.npmjs.org/'
+      config.publish.registries = [
+        { name: 'nexus', registry: 'https://nexus.internal/repo/' },
+      ]
+
+      await publishPackage({
+        pkg,
+        config,
+        packageManager: 'npm',
+        dryRun: false,
+      })
+
+      expect(loggerSpy).toHaveBeenCalledWith(expect.stringContaining('[default]'))
+      expect(loggerSpy).toHaveBeenCalledWith(expect.stringContaining('[nexus]'))
+    })
+
+    it('Then stops at the first failing registry and does not attempt the next one (fail-fast)', async () => {
+      config.publish.registry = 'https://registry.npmjs.org/'
+      config.publish.registries = [
+        { name: 'nexus', registry: 'https://nexus.internal/repo/' },
+      ]
+      vi.mocked(execPromise).mockRejectedValue(new Error('Publish failed'))
+
+      await expect(publishPackage({
+        pkg,
+        config,
+        packageManager: 'npm',
+        dryRun: false,
+      })).rejects.toThrow('Publish failed')
+
+      expect(execPromise).toHaveBeenCalledTimes(1)
+      expect(execPromise).toHaveBeenCalledWith(expect.stringContaining('--registry https://registry.npmjs.org/'), expect.any(Object))
     })
   })
 })

--- a/src/core/__tests__/npm.spec.ts
+++ b/src/core/__tests__/npm.spec.ts
@@ -688,7 +688,7 @@ describe('Given resolveRegistryTargetsForPackage function', () => {
           private: false,
           args: [],
           registry: 'https://registry.npmjs.org/',
-          registries: [{ name: 'jfrog', registry: 'https://jfrog.internal/repo/', packages: ['@scope/*'] }],
+          registries: [{ name: 'jfrog', registry: 'https://jfrog.internal/repo/', packageFilter: ['@scope/*'] }],
         },
       })
 
@@ -706,7 +706,7 @@ describe('Given resolveRegistryTargetsForPackage function', () => {
           private: false,
           args: [],
           registry: 'https://registry.npmjs.org/',
-          registries: [{ name: 'jfrog', registry: 'https://jfrog.internal/repo/', packages: ['@scope/*'] }],
+          registries: [{ name: 'jfrog', registry: 'https://jfrog.internal/repo/', packageFilter: ['@scope/*'] }],
         },
       })
 
@@ -761,7 +761,7 @@ describe('Given resolveRegistryTargetsForPackage function', () => {
           args: [],
           registry: 'https://registry.npmjs.org/',
           registries: [
-            { name: 'jfrog', registry: 'https://jfrog.internal/repo/', packages: ['@scope/*'], exclusive: true },
+            { name: 'jfrog', registry: 'https://jfrog.internal/repo/', packageFilter: ['@scope/*'], exclusive: true },
           ],
         },
       })
@@ -781,7 +781,7 @@ describe('Given resolveRegistryTargetsForPackage function', () => {
           args: [],
           registry: 'https://registry.npmjs.org/',
           registries: [
-            { name: 'jfrog', registry: 'https://jfrog.internal/repo/', packages: ['@scope/*'], exclusive: true },
+            { name: 'jfrog', registry: 'https://jfrog.internal/repo/', packageFilter: ['@scope/*'], exclusive: true },
           ],
         },
       })
@@ -800,7 +800,7 @@ describe('Given resolveRegistryTargetsForPackage function', () => {
           registry: 'https://registry.npmjs.org/',
           registries: [
             { name: 'nexus', registry: 'https://nexus.internal/repo/' },
-            { name: 'jfrog', registry: 'https://jfrog.internal/repo/', packages: ['@scope/*'], exclusive: true },
+            { name: 'jfrog', registry: 'https://jfrog.internal/repo/', packageFilter: ['@scope/*'], exclusive: true },
           ],
         },
       })
@@ -830,7 +830,7 @@ describe('Given resolveAllConfiguredRegistryTargets function', () => {
           registry: 'https://registry.npmjs.org/',
           registries: [
             { name: 'nexus', registry: 'https://nexus.internal/repo/' },
-            { name: 'jfrog', registry: 'https://jfrog.internal/repo/', packages: ['@scope/*'] },
+            { name: 'jfrog', registry: 'https://jfrog.internal/repo/', packageFilter: ['@scope/*'] },
           ],
         },
       })
@@ -1456,7 +1456,7 @@ describe('Given publishPackage function', () => {
     it('Then only publishes to a scoped registry matching the package name', async () => {
       config.publish.registry = 'https://registry.npmjs.org/'
       config.publish.registries = [
-        { name: 'jfrog', registry: 'https://jfrog.internal/repo/', packages: ['@scope/*'] },
+        { name: 'jfrog', registry: 'https://jfrog.internal/repo/', packageFilter: ['@scope/*'] },
       ]
 
       await publishPackage({
@@ -1475,7 +1475,7 @@ describe('Given publishPackage function', () => {
       vi.mocked(getIndependentTag).mockReturnValue('@scope/foo@1.0.1')
       config.publish.registry = 'https://registry.npmjs.org/'
       config.publish.registries = [
-        { name: 'jfrog', registry: 'https://jfrog.internal/repo/', packages: ['@scope/*'] },
+        { name: 'jfrog', registry: 'https://jfrog.internal/repo/', packageFilter: ['@scope/*'] },
       ]
 
       await publishPackage({

--- a/src/core/__tests__/npm.spec.ts
+++ b/src/core/__tests__/npm.spec.ts
@@ -1427,4 +1427,66 @@ describe('Given publishPackage function', () => {
       expect(execPromise).toHaveBeenCalledWith(expect.stringContaining('--registry https://registry.npmjs.org/'), expect.any(Object))
     })
   })
+
+  describe('When OTP is required across multiple registries', () => {
+    // The legacy target (built from `publish.registry`) is always resolved alongside
+    // any explicit `registries` entry, so assertions filter execPromise calls by
+    // registry URL instead of relying on call order/count across all targets.
+    function callsFor(registryHost: string) {
+      return vi.mocked(execPromise).mock.calls.filter(([command]) => (command as string).includes(registryHost))
+    }
+
+    beforeEach(() => {
+      vi.mocked(isInCI).mockReturnValue(false)
+      // Legacy target always succeeds immediately - it is not the target under test here.
+      config.publish.registry = 'https://registry.npmjs.org/'
+    })
+
+    it('Then caches the prompted OTP per registry and reuses it for the next package on that same registry', async () => {
+      config.publish.registries = [
+        { name: 'otp-reuse', registry: 'https://otp-reuse.internal/repo/' },
+      ]
+
+      vi.mocked(input).mockResolvedValueOnce('999999')
+      vi.mocked(execPromise).mockImplementation((command) => {
+        if ((command as string).includes('otp-reuse.internal') && !(command as string).includes('--otp 999999')) {
+          return Promise.reject(new Error('OTP required'))
+        }
+        return Promise.resolve({ stdout: '', stderr: '' })
+      })
+
+      await publishPackage({ pkg, config, packageManager: 'npm', dryRun: false })
+
+      // First attempt failed (no otp yet), retry succeeded with the prompted otp.
+      expect(input).toHaveBeenCalledTimes(1)
+      expect(callsFor('otp-reuse.internal')).toHaveLength(2)
+      expect(callsFor('otp-reuse.internal')[1]![0]).toContain('--otp 999999')
+
+      // A second package published to the same registry should reuse the cached OTP:
+      // no further prompt, and the command carries it on the very first attempt.
+      vi.mocked(execPromise).mockClear()
+      vi.mocked(input).mockClear()
+
+      await publishPackage({ pkg, config, packageManager: 'npm', dryRun: false })
+
+      expect(input).not.toHaveBeenCalled()
+      expect(callsFor('otp-reuse.internal')).toHaveLength(1)
+      expect(callsFor('otp-reuse.internal')[0]![0]).toContain('--otp 999999')
+    })
+
+    it('Then does not leak an OTP cached for one registry into a different, never-prompted registry', async () => {
+      // Distinct registry from the previous test - must not have any cached OTP.
+      config.publish.registries = [
+        { name: 'otp-isolated', registry: 'https://otp-isolated.internal/repo/' },
+      ]
+
+      vi.mocked(execPromise).mockResolvedValue({ stdout: '', stderr: '' })
+
+      await publishPackage({ pkg, config, packageManager: 'npm', dryRun: false })
+
+      const isolatedCalls = callsFor('otp-isolated.internal')
+      expect(isolatedCalls).toHaveLength(1)
+      expect(isolatedCalls[0]![0]).not.toContain('--otp')
+    })
+  })
 })

--- a/src/core/__tests__/npm.spec.ts
+++ b/src/core/__tests__/npm.spec.ts
@@ -733,6 +733,23 @@ describe('Given resolveRegistryTargetsForPackage function', () => {
       expect(result).toHaveLength(1)
       expect(result[0]?.name).toBe('default')
     })
+
+    it('Then still deduplicates when only the trailing slash differs', () => {
+      const config = createMockConfig({
+        bump: { type: 'patch' },
+        publish: {
+          private: false,
+          args: [],
+          registry: 'https://registry.npmjs.org', // no trailing slash
+          registries: [{ name: 'duplicate', registry: 'https://registry.npmjs.org/' }], // trailing slash
+        },
+      })
+
+      const result = resolveRegistryTargetsForPackage(pkg, config)
+
+      expect(result).toHaveLength(1)
+      expect(result[0]?.name).toBe('default')
+    })
   })
 
   describe('When a matching registry is marked exclusive', () => {
@@ -821,6 +838,25 @@ describe('Given resolveAllConfiguredRegistryTargets function', () => {
       const result = resolveAllConfiguredRegistryTargets(config)
 
       expect(result.map(t => t.name)).toEqual(['default', 'nexus', 'jfrog'])
+    })
+  })
+
+  describe('When a registry duplicates the default with only a trailing slash difference', () => {
+    it('Then deduplicates it', () => {
+      const config = createMockConfig({
+        bump: { type: 'patch' },
+        publish: {
+          private: false,
+          args: [],
+          registry: 'https://registry.npmjs.org',
+          registries: [{ name: 'duplicate', registry: 'https://registry.npmjs.org/' }],
+        },
+      })
+
+      const result = resolveAllConfiguredRegistryTargets(config)
+
+      expect(result).toHaveLength(1)
+      expect(result[0]?.name).toBe('default')
     })
   })
 })
@@ -1549,6 +1585,38 @@ describe('Given publishPackage function', () => {
       const isolatedCalls = callsFor('otp-isolated.internal')
       expect(isolatedCalls).toHaveLength(1)
       expect(isolatedCalls[0]![0]).not.toContain('--otp')
+    })
+
+    it('Then still reuses the cached OTP when the registry URL only differs by a trailing slash', async () => {
+      config.publish.registries = [
+        { name: 'otp-trailing-slash', registry: 'https://otp-trailing-slash.internal/repo' }, // no trailing slash
+      ]
+
+      vi.mocked(input).mockResolvedValueOnce('555555')
+      vi.mocked(execPromise).mockImplementation((command) => {
+        if ((command as string).includes('otp-trailing-slash.internal') && !(command as string).includes('--otp 555555')) {
+          return Promise.reject(new Error('OTP required'))
+        }
+        return Promise.resolve({ stdout: '', stderr: '' })
+      })
+
+      await publishPackage({ pkg, config, packageManager: 'npm', dryRun: false })
+
+      expect(input).toHaveBeenCalledTimes(1)
+
+      // Same registry, but declared with a trailing slash this time (different package/config).
+      vi.mocked(execPromise).mockClear()
+      vi.mocked(input).mockClear()
+      config.publish.registries = [
+        { name: 'otp-trailing-slash', registry: 'https://otp-trailing-slash.internal/repo/' }, // trailing slash
+      ]
+
+      await publishPackage({ pkg, config, packageManager: 'npm', dryRun: false })
+
+      expect(input).not.toHaveBeenCalled()
+      const calls = callsFor('otp-trailing-slash.internal')
+      expect(calls).toHaveLength(1)
+      expect(calls[0]![0]).toContain('--otp 555555')
     })
   })
 })

--- a/src/core/__tests__/redact.spec.ts
+++ b/src/core/__tests__/redact.spec.ts
@@ -47,6 +47,25 @@ describe('Given redactSecrets function', () => {
     })
   })
 
+  describe('When tokens live inside the publish.registries array', () => {
+    it('Then masks each registry entry token but keeps the registry URL', () => {
+      const result = redactSecrets({
+        publish: {
+          registry: 'https://registry.npmjs.org/',
+          registries: [
+            { name: 'nexus', registry: 'https://nexus.internal/repo/', token: 'nexus-secret-token-abcdefgh' },
+            { name: 'jfrog', registry: 'https://jfrog.internal/repo/', packages: ['@scope/*'] },
+          ],
+        },
+      })
+
+      expect(result.publish.registries[0].token).not.toContain('secret-token-abcdefgh')
+      expect(result.publish.registries[0].registry).toBe('https://nexus.internal/repo/')
+      expect(result.publish.registries[1].token).toBeUndefined()
+      expect(result.publish.registries[1].packages).toEqual(['@scope/*'])
+    })
+  })
+
   describe('When values are not sensitive', () => {
     it('Then leaves them untouched', () => {
       const result = redactSecrets({

--- a/src/core/__tests__/redact.spec.ts
+++ b/src/core/__tests__/redact.spec.ts
@@ -54,7 +54,7 @@ describe('Given redactSecrets function', () => {
           registry: 'https://registry.npmjs.org/',
           registries: [
             { name: 'nexus', registry: 'https://nexus.internal/repo/', token: 'nexus-secret-token-abcdefgh' },
-            { name: 'jfrog', registry: 'https://jfrog.internal/repo/', packages: ['@scope/*'] },
+            { name: 'jfrog', registry: 'https://jfrog.internal/repo/', packageFilter: ['@scope/*'] },
           ],
         },
       })
@@ -62,7 +62,7 @@ describe('Given redactSecrets function', () => {
       expect(result.publish.registries[0].token).not.toContain('secret-token-abcdefgh')
       expect(result.publish.registries[0].registry).toBe('https://nexus.internal/repo/')
       expect(result.publish.registries[1].token).toBeUndefined()
-      expect(result.publish.registries[1].packages).toEqual(['@scope/*'])
+      expect(result.publish.registries[1].packageFilter).toEqual(['@scope/*'])
     })
   })
 

--- a/src/core/npm.ts
+++ b/src/core/npm.ts
@@ -1,18 +1,19 @@
-import type { PackageBase, PackageManager } from '../types'
+import type { PackageBase, PackageManager, RegistryTarget } from '../types'
 import type { ResolvedRelizyConfig } from './config'
 import { execSync } from 'node:child_process'
 import { existsSync, readFileSync } from 'node:fs'
 import path, { join } from 'node:path'
 import { input } from '@inquirer/prompts'
 import { execPromise, logger } from '@maz-ui/node'
+import micromatch from 'micromatch'
 import { getIndependentTag, resolveTags } from './tags'
 import { isInCI } from './utils'
 import { isPrerelease, writeVersion } from './version'
 
 const DEFAULT_REGISTRY = 'https://registry.npmjs.org/'
 
-// Store OTP for the session to avoid re-prompting for each package
-let sessionOtp: string | undefined
+// Store OTP per registry for the session to avoid re-prompting for each package
+const sessionOtpByRegistry = new Map<string, string>()
 
 /**
  * Resolve the effective npm registry from the environment (`.npmrc` files, env
@@ -156,31 +157,101 @@ function isYarnBerry() {
   return existsSync(path.join(process.cwd(), '.yarnrc.yml'))
 }
 
+/**
+ * Build the implicit registry target from the legacy single-registry config
+ * fields (`publish.registry`/`token`/`tag`/`access`/`otp`). Publishing to this
+ * target reproduces the exact pre-multi-registry behavior.
+ */
+function buildLegacyRegistryTarget(config: ResolvedRelizyConfig): RegistryTarget {
+  return {
+    name: 'default',
+    registry: config.publish.registry ?? '',
+    token: config.publish.token || config.tokens.registry,
+    tag: config.publish.tag,
+    access: config.publish.access,
+    otp: config.publish.otp,
+  }
+}
+
+/**
+ * Deduplicate registry targets by registry URL, keeping the first occurrence
+ * (the legacy target takes priority over explicit `registries` entries).
+ */
+function dedupRegistryTargets(targets: RegistryTarget[]): RegistryTarget[] {
+  const seen = new Set<string>()
+  const result: RegistryTarget[] = []
+
+  for (const target of targets) {
+    const key = target.registry || ''
+    if (seen.has(key)) {
+      logger.debug(`Skipping duplicate registry target "${target.name ?? target.registry}"`)
+      continue
+    }
+    seen.add(key)
+    result.push(target)
+  }
+
+  return result
+}
+
+/**
+ * Resolve every distinct registry referenced by the config (legacy `registry`
+ * plus every `registries` entry, regardless of package scoping). Used for the
+ * pre-publish authentication safety check, which runs before the package list
+ * is known.
+ */
+export function resolveAllConfiguredRegistryTargets(config: ResolvedRelizyConfig): RegistryTarget[] {
+  const legacyTarget = buildLegacyRegistryTarget(config)
+  const explicitTargets = config.publish.registries ?? []
+
+  return dedupRegistryTargets([legacyTarget, ...explicitTargets])
+}
+
+/**
+ * Resolve the registry targets a given package should be published to: the
+ * legacy registry (if any) plus every `registries` entry that either has no
+ * `packages` filter (mirrored to all packages) or whose `packages` glob
+ * patterns match the package name.
+ */
+export function resolveRegistryTargetsForPackage(
+  pkg: PackageBase,
+  config: ResolvedRelizyConfig,
+): RegistryTarget[] {
+  const legacyTarget = buildLegacyRegistryTarget(config)
+  const explicitTargets = config.publish.registries ?? []
+
+  const applicableTargets = explicitTargets.filter(
+    target => !target.packages?.length || micromatch.isMatch(pkg.name, target.packages),
+  )
+
+  return dedupRegistryTargets([legacyTarget, ...applicableTargets])
+}
+
 function getCommandArgs<T extends 'auth' | 'publish'>({
   packageManager,
   tag,
-  config,
+  registryTarget,
   otp,
   type,
   dryRun,
 }: {
   packageManager: PackageManager
   tag: T extends 'publish' ? string : undefined
-  config: ResolvedRelizyConfig
+  registryTarget: RegistryTarget
   otp?: string
   type: T
   dryRun?: boolean
 }) {
   const args = type === 'publish' ? ['publish', '--tag', tag] : ['whoami']
 
-  const registry = config.publish.registry
+  const registry = registryTarget.registry
   if (registry) {
     args.push('--registry', registry)
   }
 
   const isPnpmOrNpm = packageManager === 'pnpm' || packageManager === 'npm'
 
-  const publishToken = config.publish.token || config.tokens.registry
+  const publishToken = registryTarget.token
   if (publishToken) {
     if (!registry) {
       logger.warn('Publish token provided but no registry specified')
@@ -195,8 +266,8 @@ function getCommandArgs<T extends 'auth' | 'publish'>({
     }
   }
 
-  // Priority: dynamic OTP > session OTP > config OTP
-  const finalOtp = otp ?? sessionOtp ?? config.publish.otp
+  // Priority: dynamic OTP > session OTP for this registry > target OTP
+  const finalOtp = otp ?? sessionOtpByRegistry.get(registry) ?? registryTarget.otp
   if (finalOtp) {
     args.push('--otp', finalOtp)
   }
@@ -205,7 +276,7 @@ function getCommandArgs<T extends 'auth' | 'publish'>({
     return args
   }
 
-  const access = config.publish.access
+  const access = registryTarget.access
   if (access) {
     args.push('--access', access)
   }
@@ -305,6 +376,7 @@ async function executePublishCommand({
   tag,
   dryRun,
   packageManager,
+  registryLabel,
 }: {
   command: string
   packageNameAndVersion: string
@@ -313,8 +385,9 @@ async function executePublishCommand({
   tag: string
   dryRun: boolean
   packageManager: PackageManager
+  registryLabel: string
 }): Promise<void> {
-  logger.info(`${dryRun ? '[dry-run] ' : ''}Publishing ${packageNameAndVersion} with tag "${tag}"`)
+  logger.info(`${dryRun ? '[dry-run] ' : ''}Publishing ${packageNameAndVersion} with tag "${tag}"${registryLabel}`)
 
   const dryRunPublish = dryRun && packageManager !== 'npm' && packageManager !== 'pnpm'
 
@@ -338,15 +411,17 @@ export function getAuthCommand({
   packageManager,
   config,
   otp,
+  registryTarget,
 }: {
   packageManager: PackageManager
   config: ResolvedRelizyConfig
   otp?: string
+  registryTarget?: RegistryTarget
 }): string {
   const args = getCommandArgs<'auth'>({
     packageManager,
     tag: undefined,
-    config,
+    registryTarget: registryTarget ?? buildLegacyRegistryTarget(config),
     otp,
     type: 'auth',
   })
@@ -357,20 +432,20 @@ export function getAuthCommand({
 function getPublishCommand({
   packageManager,
   tag,
-  config,
+  registryTarget,
   otp,
   dryRun,
 }: {
   packageManager: PackageManager
   tag: string
-  config: ResolvedRelizyConfig
+  registryTarget: RegistryTarget
   otp?: string
   dryRun: boolean
 }): string {
   const args = getCommandArgs<'publish'>({
     packageManager,
     tag,
-    config,
+    registryTarget,
     otp,
     dryRun,
     type: 'publish',
@@ -379,6 +454,79 @@ function getPublishCommand({
   const baseCommand = packageManager === 'yarn' && isYarnBerry() ? 'yarn npm' : packageManager
 
   return `${baseCommand} ${args.join(' ')}`
+}
+
+/**
+ * Publish a package to a single resolved registry target, retrying once with
+ * a prompted OTP if the registry requires one.
+ */
+async function publishToRegistryTarget({
+  pkg,
+  config,
+  packageManager,
+  dryRun,
+  registryTarget,
+  packageNameAndVersion,
+  registryLabel,
+}: {
+  pkg: PackageBase
+  config: ResolvedRelizyConfig
+  packageManager: PackageManager
+  dryRun: boolean
+  registryTarget: RegistryTarget
+  packageNameAndVersion: string
+  registryLabel: string
+}): Promise<void> {
+  const tag = determinePublishTag(pkg.newVersion || pkg.version, registryTarget.tag)
+
+  let dynamicOtp: string | undefined
+  const maxAttempts = 2
+
+  for (let attempt = 0; attempt < maxAttempts; attempt++) {
+    try {
+      const command = getPublishCommand({
+        packageManager,
+        tag,
+        registryTarget,
+        otp: dynamicOtp,
+        dryRun,
+      })
+
+      process.chdir(pkg.path)
+
+      await executePublishCommand({
+        command,
+        packageNameAndVersion,
+        packageManager,
+        pkg,
+        config,
+        dryRun,
+        tag,
+        registryLabel,
+      })
+
+      // Success - store OTP for this registry for next packages if it was prompted
+      if (dynamicOtp && !sessionOtpByRegistry.has(registryTarget.registry)) {
+        sessionOtpByRegistry.set(registryTarget.registry, dynamicOtp)
+        logger.debug('OTP stored for session')
+      }
+
+      return
+    }
+    catch (error) {
+      // Check if it's an OTP error and we haven't exhausted retries
+      if (isOtpError(error) && attempt < maxAttempts - 1) {
+        dynamicOtp = await handleOtpError()
+      }
+      else {
+        logger.error(`Failed to publish ${packageNameAndVersion}:`, error)
+        throw error
+      }
+    }
+    finally {
+      process.chdir(config.cwd)
+    }
+  }
 }
 
 export async function publishPackage({
@@ -392,8 +540,8 @@ export async function publishPackage({
   packageManager: PackageManager
   dryRun: boolean
 }): Promise<void> {
-  const tag = determinePublishTag(pkg.newVersion || pkg.version, config.publish.tag)
   const packageNameAndVersion = getIndependentTag({ name: pkg.name, version: pkg.newVersion || pkg.version })
+  const registryTargets = resolveRegistryTargetsForPackage(pkg, config)
 
   logger.debug(`Building publish command for ${pkg.name}`)
 
@@ -417,52 +565,24 @@ export async function publishPackage({
   }
 
   try {
-    let dynamicOtp: string | undefined
-    const maxAttempts = 2
+    // Only label the registry in logs when there is more than one target -
+    // keeps single-registry output identical to before this feature existed.
+    const showRegistryLabel = registryTargets.length > 1
 
-    for (let attempt = 0; attempt < maxAttempts; attempt++) {
-      try {
-        const command = getPublishCommand({
-          packageManager,
-          tag,
-          config,
-          otp: dynamicOtp,
-          dryRun,
-        })
+    for (const registryTarget of registryTargets) {
+      const registryLabel = showRegistryLabel
+        ? ` [${registryTarget.name ?? registryTarget.registry ?? 'default'}]`
+        : ''
 
-        process.chdir(pkg.path)
-
-        await executePublishCommand({
-          command,
-          packageNameAndVersion,
-          packageManager,
-          pkg,
-          config,
-          dryRun,
-          tag,
-        })
-
-        // Success - store OTP for next packages if it was prompted
-        if (dynamicOtp && !sessionOtp) {
-          sessionOtp = dynamicOtp
-          logger.debug('OTP stored for session')
-        }
-
-        return
-      }
-      catch (error) {
-        // Check if it's an OTP error and we haven't exhausted retries
-        if (isOtpError(error) && attempt < maxAttempts - 1) {
-          dynamicOtp = await handleOtpError()
-        }
-        else {
-          logger.error(`Failed to publish ${packageNameAndVersion}:`, error)
-          throw error
-        }
-      }
-      finally {
-        process.chdir(config.cwd)
-      }
+      await publishToRegistryTarget({
+        pkg,
+        config,
+        packageManager,
+        dryRun,
+        registryTarget,
+        packageNameAndVersion,
+        registryLabel,
+      })
     }
   }
   finally {

--- a/src/core/npm.ts
+++ b/src/core/npm.ts
@@ -222,7 +222,7 @@ export function resolveAllConfiguredRegistryTargets(config: ResolvedRelizyConfig
 /**
  * Resolve the registry targets a given package should be published to: the
  * legacy registry (if any) plus every `registries` entry that either has no
- * `packages` filter (mirrored to all packages) or whose `packages` glob
+ * `packageFilter` (mirrored to all packages) or whose `packageFilter` glob
  * patterns match the package name.
  *
  * If any applicable entry is marked `exclusive`, the legacy/default registry
@@ -237,7 +237,7 @@ export function resolveRegistryTargetsForPackage(
   const explicitTargets = config.publish.registries ?? []
 
   const applicableTargets = explicitTargets.filter(
-    target => !target.packages?.length || micromatch.isMatch(pkg.name, target.packages),
+    target => !target.packageFilter?.length || micromatch.isMatch(pkg.name, target.packageFilter),
   )
 
   const skipDefaultRegistry = applicableTargets.some(target => target.exclusive)

--- a/src/core/npm.ts
+++ b/src/core/npm.ts
@@ -174,6 +174,16 @@ function buildLegacyRegistryTarget(config: ResolvedRelizyConfig): RegistryTarget
 }
 
 /**
+ * Normalize a registry URL for comparison purposes only (trims trailing
+ * slashes), so `https://registry.npmjs.org` and `https://registry.npmjs.org/`
+ * are recognized as the same registry when deduplicating targets. The
+ * original, non-normalized URL is still what gets published to.
+ */
+function normalizeRegistryKey(registry: string): string {
+  return registry.endsWith('/') ? registry.slice(0, -1) : registry
+}
+
+/**
  * Deduplicate registry targets by registry URL, keeping the first occurrence
  * (the legacy target takes priority over explicit `registries` entries).
  */
@@ -182,7 +192,7 @@ function dedupRegistryTargets(targets: RegistryTarget[]): RegistryTarget[] {
   const result: RegistryTarget[] = []
 
   for (const target of targets) {
-    const key = target.registry || ''
+    const key = normalizeRegistryKey(target.registry || '')
     if (seen.has(key)) {
       logger.debug(`Skipping duplicate registry target "${target.name ?? target.registry}"`)
       continue
@@ -276,7 +286,7 @@ function getCommandArgs<T extends 'auth' | 'publish'>({
   }
 
   // Priority: dynamic OTP > session OTP for this registry > target OTP
-  const finalOtp = otp ?? sessionOtpByRegistry.get(registry) ?? registryTarget.otp
+  const finalOtp = otp ?? sessionOtpByRegistry.get(normalizeRegistryKey(registry)) ?? registryTarget.otp
   if (finalOtp) {
     args.push('--otp', finalOtp)
   }
@@ -515,8 +525,9 @@ async function publishToRegistryTarget({
       })
 
       // Success - store OTP for this registry for next packages if it was prompted
-      if (dynamicOtp && !sessionOtpByRegistry.has(registryTarget.registry)) {
-        sessionOtpByRegistry.set(registryTarget.registry, dynamicOtp)
+      const registryKey = normalizeRegistryKey(registryTarget.registry)
+      if (dynamicOtp && !sessionOtpByRegistry.has(registryKey)) {
+        sessionOtpByRegistry.set(registryKey, dynamicOtp)
         logger.debug('OTP stored for session')
       }
 

--- a/src/core/npm.ts
+++ b/src/core/npm.ts
@@ -212,6 +212,10 @@ export function resolveAllConfiguredRegistryTargets(config: ResolvedRelizyConfig
  * legacy registry (if any) plus every `registries` entry that either has no
  * `packages` filter (mirrored to all packages) or whose `packages` glob
  * patterns match the package name.
+ *
+ * If any applicable entry is marked `exclusive`, the legacy/default registry
+ * is skipped for this package - it is published only to the matching
+ * registries instead of mirroring on top of the default one.
  */
 export function resolveRegistryTargetsForPackage(
   pkg: PackageBase,
@@ -224,7 +228,12 @@ export function resolveRegistryTargetsForPackage(
     target => !target.packages?.length || micromatch.isMatch(pkg.name, target.packages),
   )
 
-  return dedupRegistryTargets([legacyTarget, ...applicableTargets])
+  const skipDefaultRegistry = applicableTargets.some(target => target.exclusive)
+
+  return dedupRegistryTargets([
+    ...(skipDefaultRegistry ? [] : [legacyTarget]),
+    ...applicableTargets,
+  ])
 }
 
 function getCommandArgs<T extends 'auth' | 'publish'>({

--- a/src/core/npm.ts
+++ b/src/core/npm.ts
@@ -206,9 +206,11 @@ function dedupRegistryTargets(targets: RegistryTarget[]): RegistryTarget[] {
 
 /**
  * Resolve every distinct registry referenced by the config (legacy `registry`
- * plus every `registries` entry, regardless of package scoping). Used for the
- * pre-publish authentication safety check, which runs before the package list
- * is known.
+ * plus every `registries` entry, regardless of package scoping). Conservative
+ * fallback for the pre-publish authentication safety check when the package
+ * list to publish isn't known yet - prefer `resolveRegistryTargetsForPackages`
+ * once it is, so a registry scoped to packages outside this release doesn't
+ * needlessly block it.
  */
 export function resolveAllConfiguredRegistryTargets(config: ResolvedRelizyConfig): RegistryTarget[] {
   const legacyTarget = buildLegacyRegistryTarget(config)
@@ -244,6 +246,22 @@ export function resolveRegistryTargetsForPackage(
     ...(skipDefaultRegistry ? [] : [legacyTarget]),
     ...applicableTargets,
   ])
+}
+
+/**
+ * Resolve every distinct registry actually needed to publish the given set of
+ * packages - the union of `resolveRegistryTargetsForPackage` across all of
+ * them, deduped by registry URL. Used for the pre-publish authentication
+ * safety check once the package list to publish is known, so a registry
+ * scoped to packages that are not part of this release does not block it.
+ */
+export function resolveRegistryTargetsForPackages(
+  packages: PackageBase[],
+  config: ResolvedRelizyConfig,
+): RegistryTarget[] {
+  const allTargets = packages.flatMap(pkg => resolveRegistryTargetsForPackage(pkg, config))
+
+  return dedupRegistryTargets(allTargets)
 }
 
 function getCommandArgs<T extends 'auth' | 'publish'>({

--- a/src/types.ts
+++ b/src/types.ts
@@ -459,6 +459,38 @@ export interface SocialOptions {
   ai?: boolean
 }
 
+export interface RegistryTarget {
+  /**
+   * Optional label used in logs to identify this registry (e.g. `nexus-internal`)
+   */
+  name?: string
+  /**
+   * Registry URL (e.g. `https://registry.npmjs.org/`, a Nexus or JFrog URL)
+   */
+  registry: string
+  /**
+   * Registry token - only supported for pnpm and npm
+   */
+  token?: string
+  /**
+   * Publish tag (e.g. `latest`)
+   */
+  tag?: string
+  /**
+   * Publish access level (e.g. `public` or `restricted`)
+   */
+  access?: 'public' | 'restricted'
+  /**
+   * OTP for this registry (e.g. `123456`)
+   */
+  otp?: string
+  /**
+   * Glob pattern matching package names this registry applies to.
+   * Omitted or empty = applies to every publishable package (mirroring).
+   */
+  packages?: string[]
+}
+
 export type PublishConfig = IChangelogConfig['publish'] & {
   /**
    * Package manager (e.g. `pnpm`, `npm`, `yarn` or `bun`)
@@ -504,6 +536,13 @@ export type PublishConfig = IChangelogConfig['publish'] & {
    * @default 15000
    */
   safetyCheckTimeout?: number
+  /**
+   * Additional registries to publish to, on top of `registry` (if set).
+   * Entries without `packages` apply to every package (mirroring); entries
+   * with `packages` only apply to packages matching one of the glob patterns.
+   * Fully additive: leaving this unset preserves the single-registry behavior.
+   */
+  registries?: RegistryTarget[]
 }
 
 export interface PublishOptions extends PublishConfig {

--- a/src/types.ts
+++ b/src/types.ts
@@ -489,6 +489,14 @@ export interface RegistryTarget {
    * Omitted or empty = applies to every publishable package (mirroring).
    */
   packages?: string[]
+  /**
+   * When true, packages matched by this target are published ONLY to this
+   * (and any other matching) registry - the default `publish.registry` is
+   * skipped for them. Without this flag, `registries` is purely additive:
+   * matched packages are published to this registry ON TOP OF the default one.
+   * @default false
+   */
+  exclusive?: boolean
 }
 
 export type PublishConfig = IChangelogConfig['publish'] & {

--- a/src/types.ts
+++ b/src/types.ts
@@ -485,10 +485,12 @@ export interface RegistryTarget {
    */
   otp?: string
   /**
-   * Glob pattern matching package names this registry applies to.
+   * Glob pattern matching package names this registry applies to. Distinct
+   * from `PublishConfig.packages` (which packages get published at all) -
+   * this only routes already-publishable packages to this registry.
    * Omitted or empty = applies to every publishable package (mirroring).
    */
-  packages?: string[]
+  packageFilter?: string[]
   /**
    * When true, packages matched by this target are published ONLY to this
    * (and any other matching) registry - the default `publish.registry` is
@@ -546,9 +548,10 @@ export type PublishConfig = IChangelogConfig['publish'] & {
   safetyCheckTimeout?: number
   /**
    * Additional registries to publish to, on top of `registry` (if set).
-   * Entries without `packages` apply to every package (mirroring); entries
-   * with `packages` only apply to packages matching one of the glob patterns.
-   * Fully additive: leaving this unset preserves the single-registry behavior.
+   * Entries without `packageFilter` apply to every package (mirroring);
+   * entries with `packageFilter` only apply to packages matching one of the
+   * glob patterns. Fully additive: leaving this unset preserves the
+   * single-registry behavior.
    */
   registries?: RegistryTarget[]
 }


### PR DESCRIPTION
## Summary

Adds support for publishing packages to **multiple registries** in a single release (e.g. mirroring to an internal Nexus/JFrog registry in addition to the public npm registry), addressing Relizy's current limitation of a single hardcoded registry.

The feature is **fully opt-in and backward compatible**: existing configs using `publish.registry` / `token` / `tag` / `access` / `otp` behave exactly as before. Nothing changes unless the new `publish.registries` array is set.

---

## What changed

### Config (`src/types.ts`)


### Config (`src/types.ts`)

- New `RegistryTarget` interface:
  ```ts
  interface RegistryTarget {
    name?: string
    registry: string
    token?: string
    tag?: string
    access?: 'public' | 'restricted'
    otp?: string
    packages?: string[]
  }
  ```
- `PublishConfig.registries?: RegistryTarget[]` — additive field, on top of the existing single-registry fields.
- `packages` is a list of glob patterns matched against the package name:
  - **without** `packages` → mirrored to every publishable package
  - **with** `packages` → only applied to matching packages

### Registry resolution (`src/core/npm.ts`)

- `resolveRegistryTargetsForPackage(pkg, config)` — used at publish time: legacy `registries` entry (global or glob-matched), deduped by registry URL (legacywins).
- `resolveAllConfiguredRegistryTargets(config)` — used by the pre-publish safety check, which runs *before* the package list is known, so it authenticates against every distinct configured registry regardless of package scoping.

### Publishing (`src/core/npm.ts`)

- `publishPackage` resolves targets for its package and publishes to each sequentially via a new `publishToRegistryTarget()` helper. Version temp-write for dry-run stays package-level (done once); only the publish command itself loops per registry.
- **Fail-fast, at the granularity of "the next registry/package attempt is not started"** — not atomic within a single package. If a package publishes successfully to registry A and then
fails on registry B, A's publish has already happened and is not rolled back; thore attempting anything further (no more registries for that package, no morepackages). This is a deliberate trade-off (npm/pnpm/yarn publish has no cross-registry transaction primitive to make this atomic), discussed and accepted over a "continue on error, report
at the end" alternative, which would have made *more* packages partially publish
- OTP session cache changed from a single module-level `string | undefined` to a `Map<registryUrl, otp>`, since different registries can require independent OTP challenges — a prompted OTP for one registry is no longer incorrectly reused for a different, never-prompted registry.
- Log lines only show a registry label (`[nexus]`, `[jfrog]`) when more than one target is resolved — single-registry output is byte-identical to before.

### Safety check (`src/commands/publish.ts`)

- `publishSafetyCheck` loops over `resolveAllConfiguredRegistryTargets(config)` and authenticates against each unique registry (fail-fast on the first failure).

### Programmatic API (`src/commands/publish.ts`, `release.ts`)

- `options.registries` is now forwarded into the config overrides in both `publisistent with `PublishOptions` / `ReleaseOptions` extending `PublishConfig`.

### Dependency

- Added `micromatch` (already a transitive dependency of `fast-glob`) as a **dirmatching of package names.

---

## Key technical decisions (agreed upfront)

| Decision | Rationale |
|---|---|
| Mirroring by default + optional per-package routing via glob patterns | Gives consumers flexibility for various deployment strategies |
| Fail-fast across registries and packages | Bounds the *blast radius* of a failure — nothing further is attempted. Does **not** make a single package's multi-registry publish atomic: a
package can end up published on some of its registries and not others if a later
| Dedup by registry URL, legacy wins | Prevents double-publishing to the same URL if a user redundantly re-declares the default registry inside `registries` |

---

## Testing

17 new unit tests added (**1319 total, all green**):

- [x] Target resolution: legacy-only, global mirroring, glob-scoped, dedup
- [x] `publishPackage` multi-registry + fail-fast
- [x] Per-registry OTP caching: reuse on the same registry across packages, no leak into a different never-prompted registry
- [x] `publishSafetyCheck` multi-registry + fail-fast + dedup
- [x] `redactSecrets` masking tokens inside `registries[]`

```bash
pnpm typecheck   # ✅
pnpm lint        # ✅
pnpm test:unit   # ✅ 1319 passed
pnpm build       # ✅
```

---

## Documentation

- `docs/src/config/publish.md` — new `registries` section with mirroring/scoped- on safety-check and fail-fast behavior.
- `docs/src/api/publish.md` — `registries` added to the `PublishOptions` reference.
- `README.md` — feature list updated.

---

## ⚠️ No breaking changes

Every change is additive. Without `publish.registries`, config resolution, loggire identical to the previous single-registry implementation (verified by the full
pre-existing test suite passing unmodified).